### PR TITLE
M2Crypto libraries fix

### DIFF
--- a/scripts/build_virtualenv.sh
+++ b/scripts/build_virtualenv.sh
@@ -48,8 +48,6 @@ write_extra_vars()
 {
     if [ -e $PROJECTROOT/experiment_vars.sh ]; then
         echo "export EXTRA_LD_LIBRARY_PATH=$VENV/lib" >> $PROJECTROOT/experiment_vars.sh
-        echo "export EXTRA_LD_RUN_PATH=$VENV/lib" >> $PROJECTROOT/experiment_vars.sh
-        echo "export EXTRA_LD_PRELOAD=$VENV/lib/libcrypto.so" >> $PROJECTROOT/experiment_vars.sh
     fi
 }
 
@@ -64,7 +62,6 @@ fi
 
 # TODO: Fix this mess properly
 export LD_LIBRARY_PATH=$VENV/lib:$LD_LIBRARY_PATH
-export LD_RUN_PATH=$VENV/lib:$LD_RUN_PATH
 
 if [ ! -d $VENV ]; then
     virtualenv --no-site-packages --clear $VENV
@@ -116,8 +113,6 @@ if [ ! -e $VENV/lib/python*/site-packages/M2Crypto*.egg ]; then
     python setup.py install
     popd
 fi
-
-export LD_PRELOAD=$VENV/lib/libcrypto.so
 
 echo "Testing if the EC stuff is working..."
 python -c "from M2Crypto import EC; print dir(EC)"
@@ -181,7 +176,6 @@ deactivate
 
 virtualenv --relocatable $VENV
 
-unset LD_PRELOAD
 #rm -fR venv
 #mv $VENV $VENV/../venv
 rm -fR build-tmp

--- a/scripts/build_virtualenv.sh
+++ b/scripts/build_virtualenv.sh
@@ -109,7 +109,8 @@ if [ ! -e $VENV/lib/python*/site-packages/M2Crypto*.egg ]; then
     pushd $VENV/src/M2Crypto-*/
     python setup.py build || : # Do not run this, it will break the proper stuff made by build_ext
     python setup.py build_py
-    python setup.py build_ext --openssl=$VENV
+    # This should use our custom libcrypto (explicit RPATH)
+    python setup.py build_ext --openssl=$VENV --rpath=$VENV/lib
     python setup.py install
     popd
 fi

--- a/scripts/run_in_env.sh
+++ b/scripts/run_in_env.sh
@@ -57,8 +57,6 @@ if [ ! -z "$VIRTUALENV_DIR" -a -d "$VIRTUALENV_DIR" ]; then
     export PATH=$PATH:$PWD/systemtap/inst/bin
     source $VIRTUALENV_DIR/bin/activate
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$EXTRA_LD_LIBRARY_PATH
-    export LD_RUN_PATH=$LD_RUN_PATH:$EXTRA_LD_RUN_PATH
-    export LD_PRELOAD=$LD_PRELOAD:$EXTRA_LD_PRELOAD
 fi
 # if [ "$USE_LOCAL_SYSTEMTAP" == True -o "$USE_LOCAL_VENV" == True ]; then
 # fi


### PR DESCRIPTION
LD_RUN_PATH is only used at link time to set RPATH in ELF - this is only needed for M2Crypto, but I used `setup.py build_ext --rpath=...` which does the same thing. LD_PRELOAD for libcrypto shouldn't be set because it affects ssh which in turn is used by prun.
