### PR TITLE
Python logging

### DIFF
--- a/gumby/log.py
+++ b/gumby/log.py
@@ -1,0 +1,91 @@
+import inspect
+import logging
+from os.path import normcase
+
+from twisted.python.log import PythonLoggingObserver, textFromEventDict
+
+# TODO(vladum): Maybe we can locate these source files w/o importing modules.
+import twisted.python.log
+import twisted.python.threadable
+_srcfiles = [
+    inspect.getsourcefile(twisted.python.threadable),
+    inspect.getsourcefile(twisted.python.log),
+    inspect.getsourcefile(inspect.currentframe()),
+    logging._srcfile
+]
+
+class GumbyLogger(logging.Logger):
+    """
+    Logger that walks up a few more levels on the call stack.
+
+    The original Python Logger doesn't work very nice with Twisted - it always
+    reports "log" as the module of all messages. We need to walk a few more
+    levels (see _srcfiles) to get the right originating module.
+    """
+    def findCaller(self):
+        f = logging.currentframe().f_back
+        rv = "(unknown file)", 0, "(unknown function)"
+        while hasattr(f, "f_code"):
+            co = f.f_code
+            filename = normcase(co.co_filename)
+            if filename in _srcfiles:
+                f = f.f_back
+                continue
+            rv = (filename, f.f_lineno, co.co_name)
+            break
+        return rv
+
+class ColoredFormatter(logging.Formatter):
+    """
+    Nice and shiny Python logging colored formatter.
+    """
+    _START_NORMAL = "\033[0;%dm"
+    _START_BOLD = "\033[1m"
+    _RESET_COLOR = "\033[0m"
+    
+    class _Colors:
+        RED = 1
+        GREEN = 2
+
+    _COLORS_BY_LEVEL = {
+        "INFO": _Colors.GREEN,
+        "ERROR": _Colors.RED
+    }
+
+    def _color(self, s, color, bold=False):
+        start = self._START_NORMAL
+        if bold:
+            start += self._START_BOLD
+
+        return start % (30 + color) + s + self._RESET_COLOR
+
+    def format(self, record):
+        levelname = record.levelname
+        if levelname in self._COLORS_BY_LEVEL:
+            record.msg = self._color(
+                record.msg,
+                self._COLORS_BY_LEVEL[levelname]
+            )
+        return logging.Formatter.format(self, record)
+
+class GumbyPythonLoggingObserver(PythonLoggingObserver):
+    """
+    PythonLoggingObserver that uses loggers based on originating modules.
+    """
+    def emit(self, eventDict):
+        if 'logLevel' in eventDict:
+            level = eventDict['logLevel']
+        elif eventDict['isError']:
+            level = logging.ERROR
+        else:
+            level = logging.INFO
+        text = textFromEventDict(eventDict)
+        if text is None:
+            return
+
+        # get logger based on caller
+        frame = inspect.stack()[3][0]
+        module = inspect.getmodule(frame).__name__
+        logger = logging.getLogger(module)
+
+        logger.log(level, text)

--- a/gumby/log.py
+++ b/gumby/log.py
@@ -1,3 +1,42 @@
+#!/usr/bin/env python
+# log.py ---
+#
+# Filename: log.py
+# Description:
+# Author: Vlad Dumitrescu
+# Maintainer:
+# Created: Tue Jul  23 12:14:19 2013 (+0200)
+
+# Commentary:
+# Logging helpers
+#
+#
+#
+
+# Change Log:
+#
+#
+#
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+# Floor, Boston, MA 02110-1301, USA.
+#
+#
+
+# Code:
+
 import inspect
 import logging
 from os.path import normcase
@@ -89,3 +128,6 @@ class GumbyPythonLoggingObserver(PythonLoggingObserver):
         logger = logging.getLogger(module)
 
         logger.log(level, text)
+
+#
+# log.py ends here

--- a/gumby/runner.py
+++ b/gumby/runner.py
@@ -45,6 +45,7 @@ from twisted.python.log import err, msg, Logger
 from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks, setDebugging, gatherResults, succeed
 
 from twisted.internet.protocol import ProcessProtocol
+from twisted.internet.error import ProcessTerminated
 from twisted.internet import reactor
 
 from sshclient import runRemoteCMD
@@ -325,9 +326,8 @@ class OneShotProcessProtocol(ProcessProtocol):
         self._d = Deferred()
 
     def processExited(self, reason):
-        msg("Process exited with reason: %s" % reason)
-        msg("exit code %s" % reason.value.exitCode)
-        if reason.value.exitCode:
+        msg(reason.getErrorMessage())
+        if isinstance(reason.value, ProcessTerminated):
             self._d.errback(reason)
         else:
             self._d.callback(None)

--- a/gumby/runner.py
+++ b/gumby/runner.py
@@ -333,10 +333,12 @@ class OneShotProcessProtocol(ProcessProtocol):
             self._d.callback(None)
 
     def outReceived(self, data):
-        msg("STDOUT: %s" % data.strip())
+        for line in data[:-1].split("\n"):
+            msg("STDOUT: %s" % line)
 
     def errReceived(self, data):
-        msg("STDERR: %s" % data.strip())
+        for line in data[:-1].split("\n"):
+            msg("STDERR: %s" % line)
 
     def getDeferred(self):
         return self._d

--- a/logger.conf
+++ b/logger.conf
@@ -1,0 +1,39 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=debugging,default
+
+[formatters]
+keys=debugging,default,coloreddebugging
+
+
+[logger_root]
+level=NOTSET
+handlers=debugging
+
+
+
+[handler_default]
+class=StreamHandler
+formatter=default
+args=(sys.stderr,)
+
+[handler_debugging]
+class=StreamHandler
+formatter=coloreddebugging
+args=(sys.stderr,)
+
+
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(message)s
+class=logging.Formatter
+
+[formatter_debugging]
+format=%(levelname)-7s %(created).2f %(module)15s:%(lineno)-4d  %(message)s
+class=logging.Formatter
+
+[formatter_coloreddebugging]
+format=%(levelname)-7s %(created).2f %(module)15s:%(lineno)-4d  %(message)s
+class=gumby.log.ColoredFormatter

--- a/run.py
+++ b/run.py
@@ -38,80 +38,30 @@
 # Code:
 
 import sys
-from os.path import dirname
+import os
+from twisted.internet import reactor
+from twisted.python.log import msg
 
 from gumby.settings import loadConfig
-
-from twisted.python.log import msg, FileLogObserver, textFromEventDict, _safeFormat, startLogging
-from twisted.python import util
-from twisted.internet import reactor
-
 from gumby.runner import ExperimentRunner
+from gumby.log import GumbyPythonLoggingObserver, GumbyLogger
 
-
-class ColoredFileLogObserver(FileLogObserver):
-    CANCEL_COLOR = "\x1b[0m"
-    RED_NORMAL = "\x1b[31m"
-    RED_BOLD = "\x1b[31;1m"
-    GREEN_NORMAL = "\x1b[32m"
-    GREEN_BOLD = "\x1b[32;1m"
-    GREY_NORMAL = "\x1b[37m"
-
-    def __init__(self, f=None):
-        if f is None:
-            FileLogObserver.__init__(self, sys.stdout)
-        else:
-            FileLogObserver.__init__(self, f)
-
-    def _colorize(self, text, color=GREY_NORMAL):
-        return color + text + ColoredFileLogObserver.CANCEL_COLOR
-
-    def emit(self, eventDict):
-        text = textFromEventDict(eventDict)
-        if text is None:
-            return
-
-        timeStr = self._colorize(
-            self.formatTime(eventDict['time']),
-            ColoredFileLogObserver.GREY_NORMAL)
-        fmtDict = {
-            'system': eventDict['system'],
-            'text': text.replace("\n", "\n\t")}
-        systemStr = ""
-        systemStr = self._colorize(
-           _safeFormat("[%(system)s]", fmtDict),
-           ColoredFileLogObserver.GREY_NORMAL)
-        textStr = _safeFormat("%(text)s", fmtDict)
-
-        if textStr.startswith("SSH"):
-            t = textStr.find("STDERR:")
-            if t != -1:
-                textStr = self._colorize(
-                    textStr[t + 8:],
-                    ColoredFileLogObserver.RED_BOLD)
-            else:
-                textStr = self._colorize(
-                    textStr[textStr.find("STDOUT:") + 8:],
-                    ColoredFileLogObserver.GREEN_BOLD)
-            # only text for incoming data
-            msgStr = textStr + "\n"
-        else:
-            # add system to the local logs
-            # TODO: Make system more useful, not just "SSHChannel...".
-            msgStr = systemStr + " " + textStr + "\n"
-
-        util.untilConcludes(self.write, timeStr + " " + msgStr)
-        util.untilConcludes(self.flush)  # Hoorj!
+import logging
+import logging.config
+logging.setLoggerClass(GumbyLogger)
+logging.config.fileConfig(
+    os.path.join(os.path.dirname(__file__), "logger.conf")
+)
 
 if __name__ == '__main__':
-    sys.path.append(dirname(__file__))
+    sys.path.append(os.path.dirname(__file__))
     if len(sys.argv) == 2:
         # startLogging(sys.stdout)
         # startLogging(open("/tmp/cosa.log",'w'))
-        observer = ColoredFileLogObserver()
+        observer = GumbyPythonLoggingObserver()
         observer.start()
-        config = loadConfig(sys.argv[1])
 
+        config = loadConfig(sys.argv[1])
         exp_runner = ExperimentRunner(config)
         exp_runner.run()
         reactor.run()


### PR DESCRIPTION
I propose this change to Python's logging system for more flexibility. I hope this doesn't break any existing scripts that are parsing the logs. I can re-add the old LogObserver for backward compatibility, if needed.

Now, everything is coloured in either red (stderr), or green (stdout), but we can improve this later (e.g., separate SSH from local stuff).
