### PR TITLE
Synchronize the start of the experiment by scheduling it to a global

### DIFF
--- a/gumby/sync.py
+++ b/gumby/sync.py
@@ -196,7 +196,7 @@ class ExperimentServiceFactory(Factory):
             subscriber.sendLine("id:%s" % subscriber.id)
             subscriber.sendLine(json_vars)
         msg("Data sent to all subscribers, giving the go signal in %f secs." % self.experiment_start_delay)
-        reactor.callLater(self.experiment_start_delay, self.startExperiment)
+        reactor.callLater(0, self.startExperiment)
 
     def startExperiment(self):
         # Give the go signal and disconnect

--- a/scripts/experiment_server.py
+++ b/scripts/experiment_server.py
@@ -67,7 +67,8 @@ from gumby.log import setupLogging
 from twisted.internet import reactor
 
 # @CONF_OPTION SYNC_SUBSCRIBERS_AMOUNT: Number of sync clients we should wait for to be registered before starting the experiment. (default is DAS4_INSTANCES_TO_RUN)
-# @CONF_OPTION SYNC_EXPERIMENT_START_DELAY: Amount of seconds to wait after sending the shared data to all sync clients before giving the start signal. (float, default 0)
+# @CONF_OPTION SYNC_EXPERIMENT_START_DELAY: Delay the synchronized start of the experiment by this amount of seconds when giving the start signal.
+# @CONF_OPTION SYNC_EXPERIMENT_START_DELAY: The default value should be OK for a few thousand instances. (float, default 5)
 # @CONF_OPTION SYNC_PORT: Port where we should listen on. (required)
 
 if __name__ == '__main__':
@@ -77,7 +78,7 @@ if __name__ == '__main__':
     else:
         expected_subscribers = int(environ['DAS4_INSTANCES_TO_RUN'])
 
-    experiment_start_delay = float(environ.get('SYNC_EXPERIMENT_START_DELAY', 0))
+    experiment_start_delay = float(environ.get('SYNC_EXPERIMENT_START_DELAY', 5))
     server_port = int(environ['SYNC_PORT'])
 
     reactor.listenTCP(server_port, ExperimentServiceFactory(expected_subscribers, experiment_start_delay))

--- a/scripts/run_in_env.py
+++ b/scripts/run_in_env.py
@@ -114,7 +114,7 @@ extend_var(environ, "R_SCRIPTS_PATH", r_scripts_dir)
 
 # @CONF_OPTION VIRTUALENV_DIR: Virtual env to activate for the experiment (default is ~/venv)
 # Enter virtualenv in case there's one
-running_local_and_virtualenv_disabled = not (env.get("USE_LOCAL_VENV", "False").lower() == env.get("LOCAL_RUN", "False").lower() == "True")
+running_local_and_virtualenv_disabled = not (env.get("USE_LOCAL_VENV", "False").lower() == env.get("LOCAL_RUN", "False").lower() == "true")
 if not running_local_and_virtualenv_disabled and "VIRTUALENV_DIR" in env and path.exists(expand_var(env["VIRTUALENV_DIR"])):
     venv_dir = path.abspath(expand_var(env["VIRTUALENV_DIR"]))
     print "Activating virtualenv at", venv_dir


### PR DESCRIPTION
time and taking into account the local clock differences between instances.

fixes #101
