### PR TITLE
fix metadata experiment

### DIFF
--- a/experiments/dispersy/metadata_client.py
+++ b/experiments/dispersy/metadata_client.py
@@ -36,13 +36,12 @@
 #
 
 # Code:
-import sys
 from os import path, environ
 from sys import path as pythonpath
 from hashlib import sha1
 
-from gumby.experiments.dispersyclient import DispersyExperimentScriptClient, call_on_dispersy_thread, main, \
-    buffer_online
+from gumby.experiments.dispersyclient import DispersyExperimentScriptClient, \
+    call_on_dispersy_thread, main
 
 from twisted.python.log import msg
 

--- a/gumby/experiments/dispersyclient.py
+++ b/gumby/experiments/dispersyclient.py
@@ -285,7 +285,7 @@ class DispersyExperimentScriptClient(ExperimentClient):
                 self._community = self.community_class.load_community(self._dispersy, self._master_member, *self.community_args, **self.community_kwargs)
             else:
                 msg("join community %s as %s", self._master_member.mid.encode("HEX"), self._my_member.mid.encode("HEX"))
-                self._community = self.community_class.join_community(self._dispersy, self._master_member, self._my_member, *self.community_args, **self.community_kwargs)
+                self._community = self.community_class.join_community(self._dispersy, self._master_member, self._my_member, self._my_member, *self.community_args, **self.community_kwargs)
                 self._community.auto_load = False
                 self._is_joined = True
 

--- a/scripts/extract_process_guard_stats.py
+++ b/scripts/extract_process_guard_stats.py
@@ -122,8 +122,8 @@ def parse_resource_files(input_directory, output_directory, start_timestamp=None
                 rsizes[time].setdefault(nodename, []).append(rsizes[time][pid])
 
                 # delay_io_ticks = long(parts[41])
-                write_bytes = long(parts[58])
-                read_bytes = long(parts[57])
+                write_bytes = long(parts[50])
+                read_bytes = long(parts[49])
 
                 readbytes.setdefault(time, {})[pid] = calc_diff(time, prev_times.get(pid, time), read_bytes, prev_readbytes.get(pid, read_bytes)) / 1024.0
                 writebytes.setdefault(time, {})[pid] = calc_diff(time, prev_times.get(pid, time), write_bytes, prev_writebytes.get(pid, write_bytes)) / 1024.0
@@ -133,8 +133,8 @@ def parse_resource_files(input_directory, output_directory, start_timestamp=None
                 # syscw = long(parts[48])
                 # syscr = long(parts[47])
 
-                wchar = long(parts[54])
-                rchar = long(parts[53])
+                wchar = long(parts[46])
+                rchar = long(parts[45])
 
                 rchars.setdefault(time, {})[pid] = calc_diff(time, prev_times.get(pid, time), rchar, prev_rchar.get(pid, rchar)) / 1024.0
                 wchars.setdefault(time, {})[pid] = calc_diff(time, prev_times.get(pid, time), wchar, prev_wchar.get(pid, wchar)) / 1024.0


### PR DESCRIPTION
- Fix a load_community() problem in dispersyclient.py, and hopefully community experiments should now be working.
- Fix data index problem in extract_process_guard_stats.py.
