### PR TITLE
Inserted required reference in scripts/r/annotation.r

### DIFF
--- a/scripts/r/annotation.r
+++ b/scripts/r/annotation.r
@@ -1,3 +1,4 @@
+library(plyr)
 load_annotations <- function(){
 	if(file.exists("annotations.txt")){
 		df2 <- read.table("annotations.txt", header = TRUE, check.names = FALSE, na.strings = "?")


### PR DESCRIPTION
Inserted library reference to `library(plyr)` in [scripts/r/annotation.r](https://github.com/Tribler/gumby/blob/devel/scripts/r/annotation.r), closes Tribler/gumby#203 .
