### PR TITLE
fix now that plugins are moved to triber repo root

### DIFF
--- a/scripts/stats_crawler.sh
+++ b/scripts/stats_crawler.sh
@@ -11,6 +11,6 @@ isolated_tribler_network.sh &
 STATEDIR="$OUTPUT_DIR/statsCrawler"
 
 mkdir -p $STATEDIR/sqlite/
-cd tribler/Tribler
+cd tribler/twisted
 twistd --logfile=$STATEDIR/crawler.log --pidfile=$STATEDIR/crawler.pid --nodaemon bartercast_crawler --statedir=$STATEDIR 
 cd ../..


### PR DESCRIPTION
fix for bartercast experiment, which broke because the twisted plugins were moved to the root of the tribler repo
