### PR TITLE
Switching all shebangs from python to python2.

### DIFF
--- a/experiments/dispersy/allchannel_client.py
+++ b/experiments/dispersy/allchannel_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # dummy_scenario_experiment_client.py ---
 #
 # Filename: allchannel_client.py

--- a/experiments/dispersy/barter_client.py
+++ b/experiments/dispersy/barter_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # bartercast_client.py ---
 #
 # Filename: bartercast_client.py

--- a/experiments/dispersy/demers_client.py
+++ b/experiments/dispersy/demers_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # demers_client.py ---
 #
 # Filename: demers_client.py

--- a/experiments/dispersy/discovery_client.py
+++ b/experiments/dispersy/discovery_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 from os import path, environ

--- a/experiments/dispersy/extract_demers_statistics.py
+++ b/experiments/dispersy/extract_demers_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # extract_demers_statistics.py ---
 #
 # Filename: extract_demers_statistics.py

--- a/experiments/dispersy/extract_dispersy_statistics.py
+++ b/experiments/dispersy/extract_dispersy_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import re
 import sys
 import os

--- a/experiments/dispersy/extract_privatesearch_statistics.py
+++ b/experiments/dispersy/extract_privatesearch_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # extract_privatesearch_statistics.py ---
 #
 # Filename: extract_privatesearch_statistics.py

--- a/experiments/dispersy/extract_social_statistics.py
+++ b/experiments/dispersy/extract_social_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # extract_social_statistics.py ---
 #
 # Filename: extract_social_statistics.py

--- a/experiments/dispersy/extract_tunnel_statistics.py
+++ b/experiments/dispersy/extract_tunnel_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from extract_dispersy_statistics import AbstractHandler, get_parser
 import os
 import sys

--- a/experiments/dispersy/hiddenservices_client.py
+++ b/experiments/dispersy/hiddenservices_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # bartercast_client.py ---
 #
 # Filename: hiddenservices_client.py

--- a/experiments/dispersy/metadata_client.py
+++ b/experiments/dispersy/metadata_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # social_client.py ---
 #
 # Filename: social_client.py

--- a/experiments/dispersy/privatesearch_client.py
+++ b/experiments/dispersy/privatesearch_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # privatesearch_client.py ---
 #
 # Filename: privatesearch_client.py

--- a/experiments/dispersy/privatesemantic_client.py
+++ b/experiments/dispersy/privatesemantic_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Author: Niels Zeilemaker
 
 import sys

--- a/experiments/dispersy/social_client.py
+++ b/experiments/dispersy/social_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # social_client.py ---
 #
 # Filename: social_client.py

--- a/experiments/dispersy/tunnel_client.py
+++ b/experiments/dispersy/tunnel_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from os import path
 from sys import path as pythonpath

--- a/experiments/dummy/dummy_experiment_client.py
+++ b/experiments/dummy/dummy_experiment_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # experiment_client.py ---
 #
 # Filename: experiment_client.py

--- a/experiments/libswift/parser.py
+++ b/experiments/libswift/parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 import glob

--- a/experiments/tribler_idle_run/tribler_idle_run.py
+++ b/experiments/tribler_idle_run/tribler_idle_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # tribler_idle_run.py ---
 #
 # Filename: test_30m_run.py

--- a/gumby/config.py
+++ b/gumby/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # config.py ---
 #
 # Filename: config.py

--- a/gumby/experiments/dispersyclient.py
+++ b/gumby/experiments/dispersyclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # dispersyclient.py ---
 #
 # Filename: dispersyclient.py

--- a/gumby/runner.py
+++ b/gumby/runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # run.py ---
 #
 # Filename: run.py

--- a/gumby/scenario.py
+++ b/gumby/scenario.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # scenario.py ---
 #
 # Filename: scenario.py

--- a/legacy_experiments/private_search/extract-search-statistics
+++ b/legacy_experiments/private_search/extract-search-statistics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 from time import mktime
 import re

--- a/legacy_experiments/scripts/das4-config-sync-client.py
+++ b/legacy_experiments/scripts/das4-config-sync-client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 from sys import argv, exit
 from os import getpid

--- a/legacy_experiments/scripts/das4-config-sync-server.py
+++ b/legacy_experiments/scripts/das4-config-sync-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 #  Synchronized publisher

--- a/legacy_experiments/scripts/das4-start
+++ b/legacy_experiments/scripts/das4-start
@@ -42,13 +42,13 @@ svnversion | sed 's/.*:\([0-9]*\)*[A-Z]*$/\1/g' > "$PEERS_DIRECTORY/output/svn_v
 echo "* Cleaning up *.pyc files..."
 find . -iregex '.*\(dispersy\|Community\).*\.py[co]' -delete
 echo "* Recompiling python classes..."
-(/usr/bin/env python | grep -v Listing ) <<END
+(/usr/bin/env python2 | grep -v Listing ) <<END
 from compileall import compile_dir
 import re
 compile_dir('.', rx=re.compile('/[.]svn'), force=False)
 END
 
-(/usr/bin/env python -O | grep -v Listing ) <<END
+(/usr/bin/env python2 -O | grep -v Listing ) <<END
 from compileall import compile_dir
 import re
 compile_dir('.', rx=re.compile('/[.]svn'), force=False)

--- a/legacy_experiments/scripts/ec-generator.py
+++ b/legacy_experiments/scripts/ec-generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Generate a list of peers to use with clusten run
 # The list is in the following format:

--- a/legacy_experiments/scripts/generate-graphs
+++ b/legacy_experiments/scripts/generate-graphs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 # setup once

--- a/legacy_experiments/scripts/reduce-statistics
+++ b/legacy_experiments/scripts/reduce-statistics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 from math import ceil

--- a/legacy_experiments/scripts/synthetic-generator.py
+++ b/legacy_experiments/scripts/synthetic-generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from time import mktime
 import re

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # run.py ---
 #
 # Filename: run.py

--- a/scripts/build_virtualenv.sh
+++ b/scripts/build_virtualenv.sh
@@ -432,7 +432,7 @@ rm -rf $VENV/lib/python2.7/site-packages/PIL
 
 #pip install --upgrade pip
 
-sed -i 's~#!/usr/bin/env python2.6~#!/usr/bin/env python~' $VENV/bin/*
+sed -i 's~#!/usr/bin/env python2.6~#!/usr/bin/env python2~' $VENV/bin/*
 easy_install pip
 
 echo "
@@ -460,7 +460,7 @@ cryptography
 " > ~/requirements.txt
 
 # For some reason the pip scripts get a python 2.6 shebang, fix it.
-sed -i 's~#!/usr/bin/env python2.6~#!/usr/bin/env python~' $VENV/bin/pip*
+sed -i 's~#!/usr/bin/env python2.6~#!/usr/bin/env python2~' $VENV/bin/pip*
 
 # numpy # used for report generation scripts from Cor-Paul, installed all by itself as it fails to build if we pass CFLAGS & co.
 pip install numpy

--- a/scripts/experiment_server.py
+++ b/scripts/experiment_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # experiment_server.py ---
 #
 # Filename: experiment_server.py

--- a/scripts/extract_process_guard_stats.py
+++ b/scripts/extract_process_guard_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 from sys import argv, exit

--- a/scripts/generate_config_file.py
+++ b/scripts/generate_config_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # create_conf.py ---
 #
 # Filename: create_conf.py

--- a/scripts/modify_annotations.py
+++ b/scripts/modify_annotations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 

--- a/scripts/process_guard.py
+++ b/scripts/process_guard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Mircea Bardac
 # Rewritten by Elric Milon (Dec. 2012 and Aug. 2013)
 

--- a/scripts/pycompile.py
+++ b/scripts/pycompile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # pycompile.py ---
 #
 # Filename: pycompile.py

--- a/scripts/reduce_dispersy_statistics.py
+++ b/scripts/reduce_dispersy_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 from math import ceil

--- a/scripts/run_in_env.py
+++ b/scripts/run_in_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # run_in_env.py ---
 #
 # Filename: run_in_env.py

--- a/scripts/stap_calculate_similarity.py
+++ b/scripts/stap_calculate_similarity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 Created on Jul 16, 2013
 

--- a/scripts/stap_calculate_similarity_batch.py
+++ b/scripts/stap_calculate_similarity_batch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 Created on Jul 16, 2013
 

--- a/scripts/stap_create_summary_report.py
+++ b/scripts/stap_create_summary_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 Created on Aug 6, 2013
 

--- a/scripts/stap_generate_profile.py
+++ b/scripts/stap_generate_profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 Created on Jul 16, 2013
 

--- a/scripts/stap_generate_profile_batch.py
+++ b/scripts/stap_generate_profile_batch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 Created on Jul 16, 2013
 

--- a/scripts/stap_insert_revision.py
+++ b/scripts/stap_insert_revision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sqlite3
 import sys
 import os

--- a/scripts/stap_make_io_writes_report.py
+++ b/scripts/stap_make_io_writes_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys

--- a/scripts/stap_make_similarity_report.py
+++ b/scripts/stap_make_similarity_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys

--- a/scripts/stap_split_csv_files.py
+++ b/scripts/stap_split_csv_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 Created on Aug 26, 2013
 

--- a/scripts/stap_store_run_in_database.py
+++ b/scripts/stap_store_run_in_database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 Created on Jul 16, 2013
 


### PR DESCRIPTION
Currently all shebangs specify /usr/bin/env python.
This prevents anything from running on a system where
python is python3. This commit changes all /usr/bin/env python
shebangs to /usr/bin/env python2, allowing experiments
to run on above mentioned systems.
