### PR TITLE
Don't use the wrap_in_vnc script in an OS X environment

### DIFF
--- a/scripts/wrap_in_temp_home.sh
+++ b/scripts/wrap_in_temp_home.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+
+# Looks like $TMPDIR doesn't exist in the DAS4
+if [ ! -z "$TMPDIR" ]; then
+    mkdir -p "$TMPDIR"
+fi
+
+export HOME=$(mktemp -d)
+
+if [ ! -e $HOME ]; then
+    echo "Something went wrong while creating the temporary execution dir, aborting."
+    exit 3
+fi
+
+echo "Using temporary home directory: $HOME"
+
+if [ ! -z "$HOME_SEED_FILE" ]; then
+    export HOME_SEED_FILE
+
+    if [ -e "$HOME_SEED_FILE" ]; then
+        echo "Unpacking HOME seed file: $HOME_SEED_FILE"
+        cd $HOME
+        tar xaf $HOME_SEED_FILE
+        cd -
+        echo "Done"
+    else
+        echo "HOME_SEED_FILE ($HOME_SEED_FILE) does not exist. Bailing out"
+        exit 4
+    fi
+else
+    echo "HOME_SEED_FILE not set, using a clean fake home"
+fi
+
+$* || FAILURE=$?
+
+rm -fR $HOME
+
+exit $FAILURE

--- a/scripts/wrap_in_vnc.sh
+++ b/scripts/wrap_in_vnc.sh
@@ -39,48 +39,13 @@
 
 export DISPLAY=:$RANDOM
 
-# Looks like $TMPDIR doesn't exist in the DAS4
-if [ ! -z "$TMPDIR" ]; then
-    mkdir -p "$TMPDIR"
-fi
-
-export HOME=$(mktemp -d)
-
-if [ ! -e $HOME ]; then
-    echo "Something went wrong while creating the temporary execution dir, aborting."
-    exit 3
-fi
-
-mkdir -p $HOME/.vnc # TODO: I think this is no longer needed
-
-chmod -fR og-rwx $HOME/.vnc
-
-if [ ! -z "$HOME_SEED_FILE" ]; then
-    export HOME_SEED_FILE
-
-    if [ -e "$HOME_SEED_FILE" ]; then
-        echo "Unpacking HOME seed file: $HOME_SEED_FILE"
-        cd $HOME
-        tar xaf $HOME_SEED_FILE
-        cd -
-        echo "Done"
-    else
-        echo "HOME_SEED_FILE ($HOME_SEED_FILE) does not exist. Bailing out"
-        exit 4
-    fi
-else
-    echo "HOME_SEED_FILE not set, using a clean fake home"
-fi
-
 Xvnc $DISPLAY -localhost -SecurityTypes None &
 
 sleep 1
 
-$* || FAILURE=$?
+wrap_in_temp_home.sh $* || FAILURE=$?
 
 kill %Xvnc || (sleep 1 ; kill -9 %Xvnc) ||:
-
-rm -fR $HOME
 
 exit $FAILURE
 


### PR DESCRIPTION
The wrap_in_vnc script is used to wrap the Tribler tests in a vnc environment on the headless Linux server. On OS X we will not use vnc and let Tribler run normally.
