### PR TITLE
Added pylint checker script

### DIFF
--- a/experiments/tribler/run_pylint_checker.conf
+++ b/experiments/tribler/run_pylint_checker.conf
@@ -1,0 +1,11 @@
+experiment_name = TriblerPylintChecker
+
+local_setup_cmd = tribler_experiment_setup.sh
+
+pylint_run_dir = tribler
+
+pylint_ignore_dirs = .git,dispersy,pymdht,libnacl
+
+local_instance_cmd = run_pylint_check.sh
+
+use_local_venv = False

--- a/scripts/run_pylint_check.sh
+++ b/scripts/run_pylint_check.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This scripts runs the pylint checker on a given input directory
+
+# @CONF_OPTION PYLINT_IGNORE_DIRS: Specify which directories should be ignored by Pylint (default is '')
+
+# @CONF_OPTION PYLINT_RUN_DIR: Specify from which directory pylint should run (default is $PWD)
+if [ ! -z "$PYLINT_RUN_DIR" ]; then
+cd $PYLINT_RUN_DIR
+fi
+
+echo "Running pylint (ignored directories: ${PYLINT_IGNORE_DIRS})"
+pylint --ignore=${PYLINT_IGNORE_DIRS} --output-format=parseable --reports=y Tribler > ${OUTPUT_DIR}/pylint.out 2> ${OUTPUT_DIR}/pylint.log


### PR DESCRIPTION
This scripts runs the pylint checker and has three input options:
-i : the input directory of pylint
-o : the output directory where pylint will store the `pylint.log` and `pylint.out` files
-e : an optional option with directories to exclude (comma-separated)
