### PR TITLE
Added conditional import for get_pid_list

### DIFF
--- a/run.py
+++ b/run.py
@@ -39,7 +39,7 @@
 
 import logging
 import sys
-from os import environ, getpgid, getpid, getppid, kill, setpgrp
+from os import environ, getpgid, getpid, kill, setpgrp
 from os.path import dirname, exists
 from signal import SIGKILL, SIGTERM, signal
 from time import sleep, time
@@ -47,7 +47,12 @@ from time import sleep, time
 
 logging.basicConfig(level=getattr(logging, environ.get('GUMBY_LOG_LEVEL', 'INFO').upper()))
 
-from psutil import get_pid_list
+# This conditional import is added to support older versions of psutil
+try:
+    from psutil import get_pid_list as pids
+except ImportError:
+    from psutil import pids
+
 from twisted.internet import reactor
 
 from gumby.runner import ExperimentRunner
@@ -65,7 +70,7 @@ def _killGroup(signal=SIGTERM):
     _terminating = True
     mypid = getpid()
     pids_found = 0
-    for pid in get_pid_list():
+    for pid in pids():
         try:
             if getpgid(pid) == mypid and pid != mypid:
                 kill(pid, signal)

--- a/scripts/process_guard.py
+++ b/scripts/process_guard.py
@@ -6,7 +6,7 @@ import exceptions
 import json
 from glob import iglob
 from math import ceil
-from os import (R_OK, SEEK_END, access, errno, getpgid, getpid, kill, killpg, makedirs, path, setsid, sysconf,
+from os import (R_OK, access, errno, getpgid, getpid, kill, killpg, makedirs, path, setsid, sysconf,
                 sysconf_names)
 from signal import SIGKILL, SIGTERM, signal
 from subprocess import Popen


### PR DESCRIPTION
This conditional import adds support for newer versions of `psutil` where the `get_pid_list` method is renamed to `pids`. This fixes #249.

This change should require no changes in other scripts. It has been tested on OS X and Linux with older and newer versions of `psutil`.

I also removed some unused imports.
