### PR TITLE
Unit tests on OS X and Windows

### DIFF
--- a/scripts/run_nosetests_for_jenkins.sh
+++ b/scripts/run_nosetests_for_jenkins.sh
@@ -71,7 +71,7 @@ echo Nose will run from $PWD
 
 # TODO(emilon): Make the timeout configurable
 
-NOSEARGS_COMMON="--with-xunit --all-modules --traverse-namespace --cover-package=Tribler --cover-inclusive "
+NOSEARGS_COMMON="--with-xunit --all-modules --traverse-namespace --cover-package=Tribler --cover-tests --cover-inclusive "
 NOSECMD="nosetests -v --with-xcoverage --xcoverage-file=$OUTPUT_DIR/coverage.xml --xunit-file=$OUTPUT_DIR/nosetests.xml.part $NOSEARGS_COMMON"
 
 export NOSE_LOGFORMAT="%(levelname)-7s %(created)d %(module)15s:%(name)s:%(lineno)-4d %(message)s"


### PR DESCRIPTION
This PR makes it possible to run the unit tests of Tribler on OS X and Windows.

Note that we are not using the process guard due to lack of `procfs` on OS X (see #253). The consequences of this is that we are not able to graph the resource usage (such as CPU, memory usage etc) during the tests execution.
