### PR TITLE
Modular community loading

### DIFF
--- a/docs/community_isolation.rst
+++ b/docs/community_isolation.rst
@@ -1,0 +1,83 @@
+The purpose of this document is to show a means of isolating Dispersy communities from outside interference in Gumby experiments.
+This document assumes the reader has a basic understanding of running Gumby experiments, creating Dispersy communities and running them through the ``TriblerExperimentScriptClient`` class.
+
+********************************************
+Isolating and replacing Dispersy communities
+********************************************
+As you may have noticed, the communities loaded by the ``TriblerExperimentScriptClient`` are the live communities as loaded by Tribler (which you can toggle by setting the correct flags in the ``SessionConfig``).
+In some cases this may be desirable functionality, in other cases one would like to isolate these communities as such that they do not communicate with third parties.
+
+How have we solved this in the past?
+As you may know, part of the unique identification of a Dispersy community is its master member definition.
+Previously, one was required to create a subclass of the community under test in Gumby which had a different master member definition.
+Even though this is still possible, a system has been implemented in Gumby which allows you to easily isolate and/or replace these existing Tribler communities or add your own.
+
+Isolation
+---------
+To demonstrate the use of community isolation we will use the following subclass of ``TriblerExperimentScriptClient``:
+
+.. code-block:: python
+
+    class MyTriblerExperimentScriptClientSubclass(TriblerExperimentScriptClient):
+
+        def create_community_loader(self):
+            loader = super(MyTriblerExperimentScriptClientSubclass, self).create_community_loader()
+            loader.isolate("HiddenTunnelCommunity")
+            return loader
+
+What we are doing here is overwriting the ``TriblerExperimentScriptClient.create_community_loader`` method and modifying the default ``IsolatedCommunityLoader`` it returns.
+Specifically, we are asking the ``IsolatedCommunityLoader`` to isolate a community with the name ``"HiddenTunnelCommunity"``, which happens to be one of the communities loaded by default (if we don't modify the ``SessionConfig``).
+
+You can also perform isolation with your own communities.
+To do this, you will have to write your own launcher.
+We will go over the basics of this in the following section.
+
+My First CommunityLauncher
+--------------------------
+Now that you know how to isolate existing communities, let's go over adding your own communities to ``TriblerExperimentScriptClient``.
+In this example we will create a custom ``CommunityLauncher``, in the next section we will discuss more advanced functionality which the ``CommunityLauncher`` offers.
+Consider the following minimal example, which sets up a launcher for some community class ``MyFirstCommunity``:
+
+.. code-block:: python
+
+    class MyFirstCommunityLauncher(CommunityLauncher):
+
+        def get_name(self):
+            return "MyFirstCommunity"
+
+        def get_community_class(self):
+            return MyFirstCommunity
+
+    class MyTriblerExperimentScriptClientSubclass(TriblerExperimentScriptClient):
+
+        def create_community_loader(self):
+            loader = super(MyTriblerExperimentScriptClientSubclass, self).create_community_loader()
+            # Register our custom community
+            loader.set_launcher(MyFirstCommunityLauncher())
+            # Which we can isolate as well
+            loader.isolate("MyFirstCommunity")
+            return loader
+
+As you can see, a minimal ``CommunityLauncher`` implementation requires a name and a community class to be defined.
+A launcher is uniquely identified by its name.
+**If you use ``set_launcher`` with an existing name, the current launcher will be overwritten.**
+In some cases overwriting a default community entirely may be desired though.
+
+CommunityLauncher Interface
+---------------------------
+The reference for the methods of the ``CommunityLauncher`` is as follows:
+
+========================================== =========== ===========
+Method                                     Type        Description
+========================================== =========== ===========
+``get_name()``                             *str*       The unique name of this launcher.
+``not_before()``                           *list(str)* The names of launchers which should be loaded before this launcher is launched. Use in combination with ``prepare()`` to retrieve runtime information from other communities.
+``should_launch(session)``                 *bool*      Checks the Session parameters to see if this community should be loaded.
+``prepare(dispersy, session)``             *None*      Prepare this launcher with information from the current ``Session``.
+``finalize(dispersy, session, community)`` *None*      Called after the community has been loaded. The community may be ``None`` if the ``load()`` setting evaluates to ``False`` or Dispersy failed to load the community.
+``get_community_class()``                  *Community* The class of the community to be loaded by Dispersy.
+``get_my_member(dispersy, session)``       *Member*    The Dispersy member to use for this community.
+``should_load_now(session)``               *bool*      Load this community right now, should be ``True`` in most cases. The alternative is to call ``init_community()`` later. The ``IsolatedCommunityWrapper`` uses this mechanism to provide a custom master member.
+``get_args(session)``                      *tuple*     The arguments to supply to the ``init_community()`` method of the loaded community class.
+``get_kwargs(session)``                    *dict*      The named arguments to supply to the ``init_community()`` method of the loaded community class.
+========================================== =========== ===========

--- a/gumby/experiments/community_launcher.py
+++ b/gumby/experiments/community_launcher.py
@@ -1,0 +1,221 @@
+from abc import ABCMeta, abstractmethod
+
+
+class CommunityLauncher(object):
+
+    """
+    Object in charge of preparing a Community for loading in Dispersy.
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def get_name(self):
+        """
+        Get the launcher name, for pre-launch organisation.
+
+        :rtype: str
+        """
+        return "UNKNOWN"
+
+    def not_before(self):
+        """
+        Should not launch this before some other launcher has completed.
+
+        :return: The list of launcher names to complete before this is launched
+        """
+        return []
+
+    def should_launch(self, session):
+        """
+        Check whether this launcher should launch.
+
+        For example:
+
+            return session.get_tunnel_community_enabled()
+
+        :type session: Tribler.Core.Session.Session
+        :rtype: bool
+        """
+        return True
+
+    def prepare(self, dispersy, session):
+        """
+        Perform setup tasks before the community is loaded.
+
+        :type dispersy: Tribler.dispersy.dispersy.Dispersy
+        :type session: Tribler.Core.Session.Session
+        """
+        pass
+
+    def finalize(self, dispersy, session, community):
+        """
+        Perform cleanup tasks after the community has been loaded.
+
+        :type dispersy: Tribler.dispersy.dispersy.Dispersy
+        :type session: Tribler.Core.Session.Session
+        :type community: Tribler.dispersy.community.Community or None
+        """
+        pass
+
+    @abstractmethod
+    def get_community_class(self):
+        """
+        Get the Community class this launcher wants to load.
+
+        :rtype: Tribler.dispersy.community.Community.__class__
+        """
+        pass
+
+    def get_my_member(self, dispersy, session):
+        """
+        Get the member to load the community with.
+
+        :rtype: Tribler.dispersy.member.Member
+        """
+        return session.dispersy_member
+
+    def should_load_now(self, session):
+        """
+        Load this class immediately, or perform init_community() later manually.
+
+        :rtype: bool
+        """
+        return True
+
+    def get_args(self, session):
+        """
+        Get the args to load the community with.
+
+        :rtype: tuple
+        """
+        return ()
+
+    def get_kwargs(self, session):
+        """
+        Get the kwargs to load the community with.
+
+        :rtype: dict or None
+        """
+        return {'tribler_session': session}
+
+
+class SearchCommunityLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return "SearchCommunity"
+
+    def should_launch(self, session):
+        return session.get_enable_torrent_search()
+
+    def get_community_class(self):
+        from Tribler.community.search.community import SearchCommunity
+        return SearchCommunity
+
+
+class AllChannelCommunityLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return "AllChannelCommunity"
+
+    def should_launch(self, session):
+        return session.get_enable_channel_search()
+
+    def get_community_class(self):
+        from Tribler.community.allchannel.community import AllChannelCommunity
+        return AllChannelCommunity
+
+
+class BarterCommunityLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return "BarterCommunity"
+
+    def should_launch(self, session):
+        return session.get_barter_community_enabled()
+
+    def get_community_class(self):
+        from Tribler.community.bartercast4.community import BarterCommunity
+        return BarterCommunity
+
+    def get_kwargs(self, session):
+        return {}
+
+
+class ChannelCommunityLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return "ChannelCommunity"
+
+    def should_launch(self, session):
+        return session.get_channel_community_enabled()
+
+    def get_community_class(self):
+        from Tribler.community.channel.community import ChannelCommunity
+        return ChannelCommunity
+
+
+class PreviewChannelCommunityLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return "PreviewChannelCommunity"
+
+    def should_launch(self, session):
+        return session.get_preview_channel_community_enabled()
+
+    def get_community_class(self):
+        from Tribler.community.channel.preview import PreviewChannelCommunity
+        return PreviewChannelCommunity
+
+    def should_load_now(self, session):
+        return False
+
+
+class HiddenTunnelCommunityLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return "HiddenTunnelCommunity"
+
+    def not_before(self):
+        return ["MultiChainCommunity",]
+
+    def should_launch(self, session):
+        return session.get_tunnel_community_enabled()
+
+    def get_community_class(self):
+        from Tribler.community.tunnel.hidden_community import HiddenTunnelCommunity
+        return HiddenTunnelCommunity
+
+    def get_my_member(self, dispersy, session):
+        if session.get_enable_multichain():
+            keypair = session.multichain_keypair
+            return dispersy.get_member(private_key=keypair.key_to_bin())
+        else:
+            keypair = dispersy.crypto.generate_key(u"curve25519")
+            return dispersy.get_member(private_key=dispersy.crypto.key_to_bin(keypair))
+
+    def get_kwargs(self, session):
+        from Tribler.community.tunnel.tunnel_community import TunnelSettings
+        shared_args = super(HiddenTunnelCommunityLauncher, self).get_kwargs(session)
+        shared_args['settings'] = TunnelSettings(tribler_session=session)
+        return shared_args
+
+    def finalize(self, dispersy, session, community):
+        session.lm.tunnel_community = community
+
+
+class MultiChainCommunityLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return "MultiChainCommunity"
+
+    def should_launch(self, session):
+        return session.get_enable_multichain()
+
+    def get_community_class(self):
+        from Tribler.community.multichain.community import MultiChainCommunity
+        return MultiChainCommunity
+
+    def get_my_member(self, dispersy, session):
+        keypair = session.multichain_keypair
+        return dispersy.get_member(private_key=keypair.key_to_bin())

--- a/gumby/experiments/gumby_session.py
+++ b/gumby/experiments/gumby_session.py
@@ -1,0 +1,135 @@
+import logging
+import time as timemod
+
+from os import path
+from sys import path as pythonpath
+
+from gumby.experiments.community_launcher import *
+
+# TODO(emilon): Fix this crap
+pythonpath.append(path.abspath(path.join(path.dirname(__file__), '..', '..', '..', "./tribler")))
+
+from Tribler.Core.Session import Session
+from Tribler.Core.APIImplementation.LaunchManyCore import TriblerLaunchMany
+from Tribler.dispersy.util import blocking_call_on_reactor_thread
+
+
+class CommunityLoader(object):
+
+    """
+    Object in charge of loading communities into Dispersy.
+    """
+
+    def __init__(self):
+        self.community_launchers = {}
+
+    def set_launcher(self, launcher):
+        """
+        Register a launcher to be launched by name.
+
+        If a launcher for the same name already existed, it is overwritten.
+
+        :type launcher: CommunityLauncher
+        """
+        assert isinstance(launcher, CommunityLauncher)
+
+        if launcher.get_name() in self.community_launchers:
+            logging.warning("Overriding CommunityLauncher %s", launcher.get_name())
+
+        self.community_launchers[launcher.get_name()] = (launcher, False)
+
+    def load(self, dispersy, session):
+        """
+        Load all of the communities specified by the registered launchers into Dispersy.
+
+        :type dispersy: Tribler.dispersy.dispersy.Dispersy
+        :type session: Tribler.Core.Session.Session
+        """
+        remaining = [launcher for launcher, _ in self.community_launchers.values()]
+        cycle = len(remaining)*len(remaining)
+        while remaining and cycle >= 0:
+            launcher = remaining.pop(0)
+            cycle -= 1
+            if launcher.should_launch(session):
+                validated = True
+                for dependency in launcher.not_before():
+                    # If the dependency does not exist, don't wait for it
+                    # If the dependency is never loaded, don't wait for it
+                    if dependency in self.community_launchers and \
+                            self.community_launchers[dependency][0].should_launch(session):
+                        _, loaded = self.community_launchers[dependency]
+                        validated = validated and loaded
+                if validated:
+                    self._launch(launcher, dispersy, session)
+                else:
+                    remaining.append(launcher)
+        if cycle < 0:
+            launcher_names = [launcher.get_name() for launcher in remaining]
+            raise RuntimeError("Cycle detected in CommunityLauncher not_before(): %s" % (str(launcher_names)))
+
+    def _launch(self, launcher, dispersy, session):
+        """
+        Launch a launcher: register the community with Dispersy.
+        """
+        # Prepare launcher
+        launcher.prepare(dispersy, session)
+        # Register community
+        community_class = launcher.get_community_class()
+        member = launcher.get_my_member(dispersy, session)
+        load_now = launcher.should_load_now(session)
+        args = launcher.get_args(session)
+        kwargs = launcher.get_kwargs(session)
+        communities = dispersy.define_auto_load(community_class, member, args, kwargs, load_now)
+        # Cleanup
+        launcher.finalize(dispersy, session, communities[0] if communities else None)
+        self.community_launchers[launcher.get_name()] = (launcher, True)
+
+
+class DefaultCommunityLoader(CommunityLoader):
+
+    """
+    DefaultCommunityLoader, mimicking TriblerLaunchMany.
+    """
+
+    def __init__(self):
+        super(DefaultCommunityLoader, self).__init__()
+        self.set_launcher(SearchCommunityLauncher())
+        self.set_launcher(AllChannelCommunityLauncher())
+        self.set_launcher(BarterCommunityLauncher())
+        self.set_launcher(ChannelCommunityLauncher())
+        self.set_launcher(PreviewChannelCommunityLauncher())
+        self.set_launcher(MultiChainCommunityLauncher())
+        self.set_launcher(HiddenTunnelCommunityLauncher())
+
+
+class GumbyLaunchMany(TriblerLaunchMany):
+
+    """
+    Overwritten TriblerLaunchMany allowing for custom community loading.
+    """
+
+    def __init__(self, community_loader=DefaultCommunityLoader()):
+        super(GumbyLaunchMany, self).__init__()
+        self.community_loader = community_loader
+
+    @blocking_call_on_reactor_thread
+    def load_communities(self):
+        self._logger.info("tribler: Preparing communities...")
+        now_time = timemod.time()
+
+        self.community_loader.load(self.dispersy, self.session)
+
+        self.session.set_anon_proxy_settings(2, ("127.0.0.1", self.session.get_tunnel_community_socks5_listen_ports()))
+
+        self._logger.info("tribler: communities are ready in %.2f seconds", timemod.time() - now_time)
+
+
+class GumbySession(Session):
+
+    """
+    Overwritten Session allowing for custom community loading in Session.lm.
+    """
+
+    def __init__(self, scfg=None, ignore_singleton=False, autoload_discovery=True):
+        super(GumbySession, self).__init__(scfg, ignore_singleton, autoload_discovery)
+        self.lm = GumbyLaunchMany()

--- a/gumby/experiments/isolated_community_loader.py
+++ b/gumby/experiments/isolated_community_loader.py
@@ -1,0 +1,132 @@
+import logging
+
+from os import path
+from sys import path as pythonpath
+
+from gumby.experiments.community_launcher import CommunityLauncher
+from gumby.experiments.gumby_session import DefaultCommunityLoader
+
+# TODO(emilon): Fix this crap
+pythonpath.append(path.abspath(path.join(path.dirname(__file__), '..', '..', '..', "./tribler")))
+
+from Tribler.dispersy.crypto import ECCrypto
+
+
+class IsolatedLauncherWrapper(CommunityLauncher):
+
+    """
+    Wrapper for another CommunityLauncher:
+    Changes the master member.
+    """
+
+    def __init__(self, child, session_id):
+        """
+        Wrap a child launcher, given a unique session id.
+
+        :type child: CommunityLauncher
+        :type session_id: str
+        """
+        self.child = child
+        self.session_id = session_id
+
+    def get_name(self):
+        return self.child.get_name()
+
+    def not_before(self):
+        return self.child.not_before()
+
+    def should_launch(self, session):
+        return self.child.should_launch(session)
+
+    def prepare(self, dispersy, session):
+        self.child.prepare(dispersy, session)
+
+    def finalize(self, dispersy, session, _):
+        """
+        Perform our own init_community() with our custom master member.
+        """
+        community = self.get_community_class().init_community(dispersy,
+                                                              self.get_master_member(dispersy),
+                                                              self.get_my_member(dispersy, session),
+                                                              *self.get_args(session),
+                                                              **self.get_kwargs(session))
+        self.child.finalize(dispersy, session, community)
+
+    def get_community_class(self):
+        return self.child.get_community_class()
+
+    def get_my_member(self, dispersy, session):
+        return self.child.get_my_member(dispersy, session)
+
+    def get_master_member(self, dispersy):
+        """
+        Generate a master member with our registered unique id for our wrapped community.
+
+        :type dispersy: Tribler.dispersy.dispersy.Dispersy
+        :rtype: Tribler.dispersy.member.Member
+        """
+        eccrypto = ECCrypto()
+        unique_id = self.get_name() + self.session_id
+        private_bin = "".join([unique_id[i] if i < len(unique_id) else "0" for i in range(68)])
+        eckey = eccrypto.key_from_private_bin("LibNaCLSK:" + private_bin)
+        master_key = eckey.pub().key_to_bin()
+        return dispersy.get_member(public_key=master_key)
+
+    def should_load_now(self, session):
+        """
+        Do not let Dispersy load the community, we will do this ourselves in finalize().
+        """
+        return False
+
+    def get_args(self, session):
+        return self.child.get_args(session)
+
+    def get_kwargs(self, session):
+        return self.child.get_kwargs(session)
+
+
+class IsolatedCommunityLoader(DefaultCommunityLoader):
+
+    """
+    Extension of DefaultCommunityLoader, allowing for isolation
+    of registered community launchers.
+
+    In other words, this allows the configuration of communities with
+    a different master member.
+    """
+
+    def __init__(self, session_id):
+        """
+        Create a new isolated community loader.
+
+        IsolatedCommunityLoaders on different machines using the same session_id
+        and the same community will share the same master member.
+        In all other cases they will not share the same master member.
+
+        :type session_id: str
+        """
+        assert isinstance(session_id, str)
+
+        super(IsolatedCommunityLoader, self).__init__()
+
+        self.session_id = session_id
+        self.isolated = []
+
+    def isolate(self, name):
+        """
+        Isolate a community by name.
+
+        See CommunityLauncher.get_name()
+        :type name: str
+        """
+        assert name in self.community_launchers.keys()
+
+        if name in self.isolated:
+            logging.warning("re-isolation of %s: you probably did not want to do this", name)
+        else:
+            self.isolated.append(name)
+
+        launcher, _ = self.community_launchers[name]
+        isolated_launcher = IsolatedLauncherWrapper(launcher, self.session_id)
+
+        self.set_launcher(isolated_launcher)

--- a/gumby/tests/__init__.py
+++ b/gumby/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+This folder contains unit tests for the Gumby testing framework.
+"""

--- a/gumby/tests/test_gumby_session.py
+++ b/gumby/tests/test_gumby_session.py
@@ -1,0 +1,65 @@
+import unittest
+
+from gumby.experiments.community_launcher import CommunityLauncher
+from gumby.experiments.gumby_session import CommunityLoader
+
+
+class MockCommunity(object):
+    pass
+
+
+class MockDispersy(object):
+
+    def __init__(self):
+        self.loaded_classes = []
+
+    def define_auto_load(self, community_class, *args):
+        self.loaded_classes.append(community_class.__name__)
+
+
+class MockUniqueLauncher(CommunityLauncher):
+
+    def get_name(self):
+        return str(id(self))
+
+    def get_community_class(self):
+        return MockCommunity
+
+    def get_my_member(self, dispersy, session):
+        return None
+
+
+class TestCommunityLoader(unittest.TestCase):
+
+    def setUp(self):
+        self.loader = CommunityLoader()
+        self.dispersy = MockDispersy()
+
+    def test_unknown_dependency(self):
+        """
+        If a dependency does not exist, the community should be loaded.
+
+        This avoids waiting forever for something which does not exist.
+        """
+        launcher = MockUniqueLauncher()
+        launcher.not_before = lambda: "I don't exist"
+        self.loader.set_launcher(launcher)
+        self.loader.load(self.dispersy, None)
+
+        self.assertListEqual(self.dispersy.loaded_classes, ["MockCommunity",])
+
+    def test_cycle_dependency(self):
+        """
+        In case of programmer cyclic dependency error, raise a RuntimeError
+        """
+        launcher1 = MockUniqueLauncher()
+        launcher2 = MockUniqueLauncher()
+        launcher3 = MockUniqueLauncher()
+        launcher1.not_before = lambda: [launcher2.get_name(),]
+        launcher2.not_before = lambda: [launcher3.get_name(),]
+        launcher3.not_before = lambda: [launcher1.get_name(),]
+        self.loader.set_launcher(launcher1)
+        self.loader.set_launcher(launcher2)
+        self.loader.set_launcher(launcher3)
+
+        self.assertRaises(RuntimeError, self.loader.load, self.dispersy, None)

--- a/gumby/tests/test_isolated_community_loader.py
+++ b/gumby/tests/test_isolated_community_loader.py
@@ -1,0 +1,75 @@
+import unittest
+
+from gumby.experiments.community_launcher import CommunityLauncher
+from gumby.experiments.isolated_community_loader import IsolatedLauncherWrapper
+
+
+class MockDispersy(object):
+
+    def get_member(self, public_key):
+        return public_key
+
+
+class MockUniqueLauncher1(CommunityLauncher):
+
+    def get_name(self):
+        return "MockUniqueLauncher1"
+
+    def get_community_class(self):
+        pass
+
+
+class MockUniqueLauncher2(CommunityLauncher):
+
+    def get_name(self):
+        return "MockUniqueLauncher2"
+
+    def get_community_class(self):
+        pass
+
+
+class TestIsolatedLauncherWrapper(unittest.TestCase):
+
+    def setUp(self):
+        self.session_id = "".join([chr(i) for i in range(64)])
+        self.dispersy = MockDispersy()
+
+    def test_same_id_same_name(self):
+        """
+        A master member is shared if session_ids and community names match
+        """
+        wrapper1 = IsolatedLauncherWrapper(MockUniqueLauncher1(), self.session_id)
+        wrapper2 = IsolatedLauncherWrapper(MockUniqueLauncher1(), self.session_id)
+
+        self.assertEqual(wrapper1.get_master_member(self.dispersy),
+                         wrapper2.get_master_member(self.dispersy))
+
+    def test_unique_id_same_name(self):
+        """
+        A master member is unique if session_ids differ and community names match
+        """
+        wrapper1 = IsolatedLauncherWrapper(MockUniqueLauncher1(), self.session_id)
+        wrapper2 = IsolatedLauncherWrapper(MockUniqueLauncher1(), "I am something else")
+
+        self.assertNotEqual(wrapper1.get_master_member(self.dispersy),
+                            wrapper2.get_master_member(self.dispersy))
+
+    def test_same_id_unique_name(self):
+        """
+        A master member is unique if session_ids match and community names are unique
+        """
+        wrapper1 = IsolatedLauncherWrapper(MockUniqueLauncher1(), self.session_id)
+        wrapper2 = IsolatedLauncherWrapper(MockUniqueLauncher2(), self.session_id)
+
+        self.assertNotEqual(wrapper1.get_master_member(self.dispersy),
+                            wrapper2.get_master_member(self.dispersy))
+
+    def test_unique_id_unique_name(self):
+        """
+        A master member is unique if session_ids and community names are unique
+        """
+        wrapper1 = IsolatedLauncherWrapper(MockUniqueLauncher1(), self.session_id)
+        wrapper2 = IsolatedLauncherWrapper(MockUniqueLauncher2(), "I am something else")
+
+        self.assertNotEqual(wrapper1.get_master_member(self.dispersy),
+                            wrapper2.get_master_member(self.dispersy))


### PR DESCRIPTION
This resolves #300 and #298. Depends on https://github.com/Tribler/tribler/pull/2815 .

This allows experiment creators to easily isolate and/or overwrite default communities with their own, through community launch profiles (CommunityLauncher objects).

### Hooks
Adds subclass `GumbySession` of `Session` which maintains a subclass `GumbyLaunchMany` of `TriblerLaunchMany`.
The `GumbyLaunchMany` overwrites the `load_communities()` method to use a `CommunityLoader` to `dispersy.define_auto_load` its communities (instead of doing this directly in `load_communities()`).
By loading this into `TriblerExperimentScriptClient`, this allows for experiment writers to easily isolate and/or overwrite default communities.

### New functionality
The default community launch behavior has been included in this PR.
In other words, running `TriblerExperimentScriptClient` will function exactly the same as the hardcoded system.
Due to loading an `IsolatedCommunityLoader` by default this allows for easy isolation of registered communities, by calling `isolate()` for a loaded community, for example:

```python
class MyTriblerExperimentScriptClientSubclass(TriblerExperimentScriptClient):

    def create_community_loader(self):
        loader = super(MyTriblerExperimentScriptClientSubclass, self).create_community_loader()
        loader.isolate("HiddenTunnelCommunity")
        return loader
```

For more drastic changes, one can even replace existing communities by means of creating a custom launcher, for example:

```python
class MyHiddenCommunityLauncher(HiddenTunnelCommunityLauncher):

    def get_community_class(self):
        return MyNewHiddenCommunityClass

class MyTriblerExperimentScriptClientSubclass(TriblerExperimentScriptClient):

    def create_community_loader(self):
        loader = super(MyTriblerExperimentScriptClientSubclass, self).create_community_loader()
        loader.set_launcher(MyHiddenCommunityLauncher)
        return loader
```

Or insert new communities:

```python
class MyNewCommunityLauncher(CommunityLauncher):

    def get_name(self):
        return "MyNewCommunity"

    def get_community_class(self):
        return MyNewCommunityClass

class MyTriblerExperimentScriptClientSubclass(TriblerExperimentScriptClient):

    def create_community_loader(self):
        loader = super(MyTriblerExperimentScriptClientSubclass, self).create_community_loader()
        # Insert a new community
        loader.set_launcher(MyNewCommunityLauncher)
        # Which you can isolate afterwards
        loader.isolate("MyNewCommunity")
        return loader
```

In more complex cases one can also create dependencies between communities:

```python
class MyNewCommunityLauncher(CommunityLauncher):

    def get_name(self):
        return "MyNewCommunity"

    def get_community_class(self):
        return MyNewCommunityClass

    def not_before(self):
        return ["HiddenTunnelCommunity",]

    def prepare(self, dispersy, session):
        print session.lm.tunnel_community.socks_server.socks5_ports
```