### PR TITLE
Use the proper keypair for the Multichain Community

### DIFF
--- a/experiments/multichain/multichain_client.py
+++ b/experiments/multichain/multichain_client.py
@@ -76,7 +76,8 @@ class MultiChainClient(TriblerExperimentScriptClient):
         """
         Load the multichain community
         """
-        my_member = self.session.get_dispersy_instance().get_member(private_key=self.my_member_private_key)
+        keypair = self.session.multichain_keypair
+        my_member = self.session.get_dispersy_instance().get_member(private_key=keypair.key_to_bin())
         self.multichain_community = self.session.get_dispersy_instance().define_auto_load(
             MultiChainCommunity, my_member, load=True, kargs={'tribler_session': self.session})[0]
 


### PR DESCRIPTION
This PR makes the multichain_client.py use the correct keypair. The default TriblerExperimentClient uses a different type of keypair, which prevents Multichain records from being countersigned in the experiment.