### PR TITLE
Added support for duplicate imports

### DIFF
--- a/gumby/experiment.py
+++ b/gumby/experiment.py
@@ -2,6 +2,7 @@ import imp
 import json
 import logging
 import os
+import sys
 from time import time
 from collections import Iterable
 from os import environ, path, makedirs, chdir
@@ -274,14 +275,16 @@ class ExperimentClient(object, LineReceiver):
         :param directory_path: the file's path
         :return: the imported module or None
         """
+        if module_name in sys.modules and sys.modules[module_name]:
+            return sys.modules[module_name]
         module = None
         f = None
         try:
             f, pathname, desc = imp.find_module(name, [directory_path, ])
             module = imp.load_module(module_name, f, pathname, desc)
-        except ImportError:
+        except ImportError as e:
             if logger:
-                logger.error("Unable to import %s from %s as %s!", name, directory_path, module_name)
+                logger.error("Unable to import %s from %s as %s: %s", name, directory_path, module_name, str(e))
         finally:
             if f:
                 f.close()

--- a/gumby/tests/test_experiment_import.py
+++ b/gumby/tests/test_experiment_import.py
@@ -36,6 +36,19 @@ class TestExperimentImport(unittest.TestCase):
         self.assertIsNone(module)
         self.assertNotIn("some.other.test.module.name", sys.modules)
 
+    def test_duplicate_import(self):
+        module1 = ExperimentClient.direct_import("some.test.module.name",
+                                                 "my_module",
+                                                 TestExperimentImport.test_class_folder)
+        module2 = ExperimentClient.direct_import("some.test.module.name",
+                                                 "my_module",
+                                                 TestExperimentImport.test_class_folder)
+
+        self.assertIsNotNone(module1)
+        self.assertIsNotNone(module2)
+        self.assertIn("some.test.module.name", sys.modules)
+        self.assertEqual(module1, module2)
+
     def test_find_modules_no_class(self):
         init_folders, class_file, classes = ExperimentClient.find_modules_for(TestExperimentImport.test_class_module)
 


### PR DESCRIPTION
Modules are only imported if they weren't already imported. This would otherwise cause a name conflict.

Also added more debug info when an import fails.