### PR TITLE
Experiment DHT isolation

### DIFF
--- a/experiments/dispersy/hidden_services_common.scenario
+++ b/experiments/dispersy/hidden_services_common.scenario
@@ -1,13 +1,16 @@
 &module gumby.modules.tribler_module.TriblerModule
+&module gumby.modules.dht_module.DHTModule
 &module experiments.dispersy.hidden_services_module.HiddenServicesModule
 
 @0:0 isolate_community HiddenTunnelCommunity
-@0:1 set_tunnel_exit True {1-2}
-@0:1 set_tunnel_exit False {3-20}
+@0:0 isolate_dht
 
-# default the hidden tunnel experiments to 100MB
-@0:1 set_transfer_size 104857600
+@0:1 set_tunnel_exit True {1-3}
+@0:1 set_tunnel_exit False {4-20}
+# default the hidden tunnel experiments to 10MB
+@0:1 set_transfer_size 10485760
 
 @0:4 start_session
+@0:6 set_libtorrentmgr_alert_mask
 @0:11 introduce_peers
 @0:20 reset_dispersy_statistics

--- a/experiments/dispersy/hidden_services_module.py
+++ b/experiments/dispersy/hidden_services_module.py
@@ -100,6 +100,10 @@ class HiddenServicesModule(CommunityExperimentModule):
         self.tunnel_settings.max_traffic = long(value)
 
     @experiment_callback
+    def set_tunnel_max_time(self, value):
+        self.tunnel_settings.max_time = long(value)
+
+    @experiment_callback
     def disable_tunnel_crypto(self):
         self._logger.error("Disable tunnel crypto")
         self.tunnel_settings.crypto = NoTunnelCrypto()

--- a/experiments/dispersy/hiddenservices-1-hop-seeder.scenario
+++ b/experiments/dispersy/hiddenservices-1-hop-seeder.scenario
@@ -6,6 +6,9 @@
 
 @0:20 transfer action=seed hops=1 {4}
 @0:100 transfer {5}
-@0:250 transfer hops=1 {6}
-@0:400 transfer hops=2 {7}
-@0:600 stop
+@0:150 transfer hops=1 {6}
+@0:160 disable_libtorrent_dht {6}
+@0:200 transfer hops=2 {7}
+@0:210 disable_libtorrent_dht {7}
+@0:400 print_dht_table
+@0:800 stop

--- a/experiments/trustchain/fullstack-small.conf
+++ b/experiments/trustchain/fullstack-small.conf
@@ -1,0 +1,22 @@
+experiment_name = "multichain_fullstack"
+experiment_time = 12090
+
+tracker_cmd = 'run_tracker.sh'
+tracker_port = 7788
+
+experiment_server_cmd = 'experiment_server.py'
+sync_port = __unique_port__
+sync_host = 127.0.0.1
+sync_subscribers_amount = 10
+sync_experiment_start_delay = 1
+
+local_instance_cmd = "process_guard.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -c launch_scenario.py -t $EXPERIMENT_TIME -m $OUTPUT_DIR  -o $OUTPUT_DIR "
+
+use_local_venv = FALSE
+
+# post_process_cmd = 'post_process_dispersy_experiment.sh'
+# dispersy_statistics_extraction_cmd = 'extract_tunnel_statistics.py'
+# extra_r_scripts_to_run = "tunnel.r"
+# messages_to_plot = 'torrent'
+
+scenario_file = 'fullstack-small.scenario'

--- a/experiments/trustchain/fullstack-small.scenario
+++ b/experiments/trustchain/fullstack-small.scenario
@@ -1,0 +1,34 @@
+&module gumby.modules.tribler_module.TriblerModule
+&module gumby.modules.dht_module.DHTModule
+&module experiments.trustchain.trustchain_module.TrustchainModule
+&module experiments.dispersy.hidden_services_module.HiddenServicesModule
+
+@0:0 isolate_community HiddenTunnelCommunity
+@0:0 isolate_community MultiChainCommunity
+@0:0 isolate_dht
+
+@0:1 set_transfer_size 16777216
+@0:1 set_tunnel_exit True {1-3,21-25}
+@0:1 set_tunnel_exit False {4-20,26-75}
+@0:1 set_tunnel_max_time 180
+
+@0:4 start_session
+@0:11 introduce_peers
+@0:20 reset_dispersy_statistics
+
+@0:50 transfer file_name=A timeout=2200 action=seed hops=2 {4-5,26-28}
+@0:60 transfer file_name=A timeout=2200 hops=2 {6-20,29-75}
+
+@0:2460 transfer file_name=B timeout=2200 action=seed hops=2 {4-5,26-28}
+@0:2480 transfer file_name=B timeout=2200 hops=2 {6-20,29-75}
+
+@0:4860 transfer file_name=C timeout=2200 action=seed hops=2 {4-5,26-28}
+@0:4880 transfer file_name=C timeout=2200 hops=2 {6-20,29-75}
+
+@0:7260 transfer file_name=D timeout=2200 action=seed hops=2 {4-5,26-28}
+@0:7280 transfer file_name=D timeout=2200 hops=2 {6-20,29-75}
+
+@0:9660 transfer file_name=E timeout=2200 action=seed hops=2 {4-5,26-28}
+@0:9680 transfer file_name=E timeout=2200 hops=2 {6-20,29-75}
+
+@0:12080 stop

--- a/gumby/modules/base_dispersy_module.py
+++ b/gumby/modules/base_dispersy_module.py
@@ -72,6 +72,7 @@ class BaseDispersyModule(ExperimentModule):
         config.set_megacache_enabled(False)
         config.set_dispersy_enabled(True)
         config.set_mainline_dht_enabled(False)
+        config.set_mainline_dht_listen_port(18000 + self.my_id)
         config.set_torrent_collecting_enabled(False)
         config.set_libtorrent_enabled(False)
         config.set_torrent_search_enabled(False)

--- a/gumby/modules/community_launcher.py
+++ b/gumby/modules/community_launcher.py
@@ -195,12 +195,26 @@ class HiddenTunnelCommunityLauncher(CommunityLauncher):
 
 class TrustChainCommunityLauncher(CommunityLauncher):
 
+    def get_community_class(self):
+        from Tribler.community.trustchain.community import TrustChainCommunity
+        return TrustChainCommunity
+
+    def get_my_member(self, dispersy, session):
+        keypair = session.trustchain_keypair
+        return dispersy.get_member(private_key=keypair.key_to_bin())
+
+    def get_kwargs(self, session):
+        return {}
+
+
+class TriblerChainCommunityLauncher(CommunityLauncher):
+
     def should_launch(self, session):
         return session.config.get_trustchain_enabled()
 
     def get_community_class(self):
-        from Tribler.community.trustchain.community import TrustChainCommunity
-        return TrustChainCommunity
+        from Tribler.community.triblerchain.community import TriblerChainCommunity
+        return TriblerChainCommunity
 
     def get_my_member(self, dispersy, session):
         keypair = session.trustchain_keypair

--- a/gumby/modules/dht_module.py
+++ b/gumby/modules/dht_module.py
@@ -1,0 +1,200 @@
+"""
+The dht module aims to provide DHT isolation for experiments, and provide dht related utility experiment callbacks.
+"""
+from random import sample
+
+from gumby.experiment import experiment_callback
+
+from gumby.modules.experiment_module import static_module, ExperimentModule
+from gumby.modules.base_dispersy_module import BaseDispersyModule
+from gumby.modules.tribler_module import TriblerModule
+
+from Tribler.Core.DecentralizedTracking.pymdht.core.routing_table import Bucket
+import Tribler.Core.DecentralizedTracking.mainlineDHT as pymdht
+import Tribler.Core.Libtorrent.LibtorrentMgr as lt
+
+
+class EverEmptySet(frozenset):
+    def add(self, _):
+        pass
+
+    def remove(self, _):
+        pass
+
+
+@static_module
+class DHTModule(ExperimentModule):
+    def __init__(self, experiment):
+        super(DHTModule, self).__init__(experiment)
+        self.dht_nodes = []
+
+    @property
+    def tribler(self):
+        trib = BaseDispersyModule.get_dispery_provider(self.experiment)
+        if not trib or not isinstance(trib, TriblerModule):
+            raise Exception("No TriblerModule loaded. Load an implementation of TriblerModule before loading the %s "
+                            "module", self.__class__.__name__)
+        return trib
+
+    @property
+    def lm(self):
+        if not self.tribler.session or not self.tribler.session.lm:
+            raise Exception("Tribler instance not started or no LaunchManyCore?!")
+        return self.tribler.session.lm
+
+    @property
+    def session_config(self):
+        if self.tribler.session_config is None:
+            return self.tribler.session
+        else:
+            return self.tribler.session_config
+
+    def on_id_received(self):
+        super(DHTModule, self).on_id_received()
+        self.session_config.set_mainline_dht(True)
+        self.vars["dht_node_port"] = self.session_config.get_mainline_dht_listen_port()
+
+    def on_all_vars_received(self):
+        super(DHTModule, self).on_id_received()
+        for node_dict in self.all_vars.itervalues():
+            if "dht_node_port" in node_dict:
+                self.dht_nodes.append((str(node_dict["host"]), int(node_dict["dht_node_port"])))
+
+    @experiment_callback
+    def print_dht_table(self):
+        self.lm.mainline_dht.controller._routing_m.table.print_table()
+        for ltsession in self.lm.ltmgr.ltsessions.itervalues():
+            ltsession.post_dht_stats()
+
+    @experiment_callback
+    def disable_libtorrent_dht(self):
+        for sess in self.lm.ltmgr.ltsessions.itervalues():
+            settings = sess.get_settings()
+            settings["enable_dht"] = False
+            sess.set_settings(settings)
+
+    @experiment_callback
+    def enable_libtorrent_dht(self):
+        for sess in self.lm.ltmgr.ltsessions.itervalues():
+            settings = sess.get_settings()
+            settings["enable_dht"] = True
+            sess.set_settings(settings)
+
+    @experiment_callback
+    def disable_pymdht_dht(self):
+        if self.lm.mainline_dht:
+            pymdht.deinit(self.lm.mainline_dht)
+            self.lm.mainline_dht = None
+
+    @experiment_callback
+    def enable_pymdht_dht(self):
+        if not self.lm.mainline_dht:
+            self.lm.mainline_dht = pymdht.init(('127.0.0.1', self.session_config.get_mainline_dht_listen_port()),
+                                               self.session_config.get_state_dir())
+
+    @experiment_callback
+    def isolate_dht(self):
+        # This dht method is not split into pymdht and libtorrent dht since having one non isolated DHT causes leakage.
+        # Call this function early, specifically before the session is started. This is to ensure the monkey patches are
+        # seen by subsequent imports.
+
+        # Pymdht has a hardcoded bootstrap. The only real option is to monkey patch it, and return nodes that we want.
+        def is_hardcoded(*_):
+            return False
+
+        def get_sample_unstable_addrs(*_):
+            return []
+
+        def get_shuffled_stable_addrs(*_):
+            return sample(self.dht_nodes, len(self.dht_nodes))
+
+        pymdht.pymdht.controller.bootstrap.OverlayBootstrapper.is_hardcoded = is_hardcoded
+        pymdht.pymdht.controller.bootstrap.OverlayBootstrapper.get_sample_unstable_addrs = get_sample_unstable_addrs
+        pymdht.pymdht.controller.bootstrap.OverlayBootstrapper.get_shuffled_stable_addrs = get_shuffled_stable_addrs
+
+        # By default pymdht will filter out local addresses in node and peer lists. There is no option to control this
+        # behaviour, so again the only solution is a patch...
+
+        def uncompact(c_addr):
+            if len(c_addr) != pymdht.pymdht.controller.message.mt.ADDR4_SIZE:
+                raise pymdht.pymdht.controller.message.mt.AddrError, 'invalid address size'
+            ip = pymdht.pymdht.controller.message.mt.inet_ntoa(c_addr[:-2])
+            port = pymdht.pymdht.controller.message.mt.bin_to_int(c_addr[-2:])
+            if port == 0:
+                pymdht.pymdht.controller.message.mt.logger.warning('c_addr: %r > port is ZERO' % c_addr)
+                raise pymdht.pymdht.controller.message.mt.AddrError
+            return (ip, port)
+
+        pymdht.pymdht.controller.message.mt.uncompact_addr = uncompact
+
+        # Using only a few hosts on the same IP it is very easy to trigger the flood barrier defence. Disable it...
+        def ip_blocked(*_):
+            return False
+
+        pymdht.pymdht.minitwisted.FloodBarrier.ip_blocked = ip_blocked
+
+        # By default pymdht's RoutingTable class will filter out multiple nodes on the same IP. It is used rather
+        # extensively, so we can't really alter the class. To fix we make sure that the "list of ip's in the table" is
+        # immutable. However we have to do this before the instance is created when pymdht is initialized. The way to do
+        # this is to monkey patch the __init__ method.
+        old_RT__init__ = pymdht.routing_mod.RoutingTable.__init__
+
+        def new_RT__init__(self, my_node, nodes_per_bucket):
+            old_RT__init__(self, my_node, nodes_per_bucket)
+            self._ips_in_main = EverEmptySet()
+
+        pymdht.routing_mod.RoutingTable.__init__ = new_RT__init__
+
+        # The same story goes for the lookup manager. It will not bootstrap from one IP multiple times.
+        old_lookup__init__ = pymdht.lookup_mod._LookupQueue.__init__
+        old_lookup_bootstrap = pymdht.lookup_mod._LookupQueue.bootstrap
+
+        def new_lookup__init__(self, info_hash, queue_size):
+            old_lookup__init__(self, info_hash, queue_size)
+            self.queued_ips = EverEmptySet()
+            self.queried_ips = EverEmptySet()
+
+        def new_lookup_bootstrap(inst, rnodes, max_nodes, overlay_bootstrap):
+            return old_lookup_bootstrap(inst, rnodes, max(max_nodes, min(20, len(self.dht_nodes))), overlay_bootstrap)
+
+        pymdht.lookup_mod._LookupQueue.__init__ = new_lookup__init__
+        pymdht.lookup_mod._LookupQueue.bootstrap = new_lookup_bootstrap
+
+        # With our edits we've broken pymdht such that it will add a node multiple times to a bucket. This causes some
+        # messaging overhead. Fix this when adding to a bucket.
+        old_Bucket_add = Bucket.add
+
+        def new_Bucket_add(self, rnode):
+            if self._find(rnode) == -1:
+                return
+            old_Bucket_add(self, rnode)
+
+        Bucket.add = new_Bucket_add
+
+        # LibTorrentMgr also requires monkey patches, an empty default dht router list and no PEX in the 0 hops case
+        original_create_session = lt.LibtorrentMgr.create_session
+        lt.DEFAULT_DHT_ROUTERS = []
+        if lt.lt.create_ut_pex_plugin in lt.DEFAULT_LT_EXTENSIONS:
+            lt.DEFAULT_LT_EXTENSIONS.remove(lt.lt.create_ut_pex_plugin)
+
+        def do_dht_check(*_):
+            pass
+
+        def create_session(inst, hops=0):
+            sess = original_create_session(inst, hops)
+            for node in self.dht_nodes:
+                sess.add_dht_node(node)
+
+            if hops == 0:
+                self.dht_nodes.append(("127.0.0.1", sess.listen_port()))
+            # else: we don't know the port of the exit socket
+
+            settings = sess.get_settings()
+            settings["enable_lsd"] = False
+            sess.set_settings(settings)
+
+            inst.dht_ready = True
+            return sess
+
+        lt.LibtorrentMgr.do_dht_check = do_dht_check
+        lt.LibtorrentMgr.create_session = create_session

--- a/gumby/modules/experiment_module.py
+++ b/gumby/modules/experiment_module.py
@@ -34,6 +34,16 @@ class ExperimentModule(object):
         return self.experiment.all_vars
 
     def on_id_received(self):
+        """
+        The experiment node has been assigned it's ID. After all the handlers for this event are completed the Vars
+        dictionary is sent to the experiment server.
+        """
+        pass
+
+    def on_all_vars_received(self):
+        """
+        The experiment server has sent us all the vars dictionaries of all the experiment nodes.
+        """
         pass
 
     @staticmethod

--- a/gumby/modules/gumby_session.py
+++ b/gumby/modules/gumby_session.py
@@ -111,7 +111,7 @@ class DefaultCommunityLoader(CommunityLoader):
         self.set_launcher(AllChannelCommunityLauncher())
         self.set_launcher(ChannelCommunityLauncher())
         self.set_launcher(PreviewChannelCommunityLauncher())
-        self.set_launcher(TrustChainCommunityLauncher())
+        self.set_launcher(TriblerChainCommunityLauncher())
         self.set_launcher(HiddenTunnelCommunityLauncher())
         self.set_launcher(MarketCommunityLauncher())
 

--- a/gumby/sync.py
+++ b/gumby/sync.py
@@ -60,6 +60,7 @@
 # Code:
 import json
 import logging
+from random import randint
 from time import time
 
 from twisted.internet import reactor
@@ -236,6 +237,13 @@ class ExperimentServiceFactory(Factory):
                 subscriber_vars['host'] = subscriber.transport.getPeer().host
             vars[subscriber.id] = subscriber_vars
 
+        vars = {
+            "server":
+                {
+                    "global_random": randint(0, (2 ** 32) - 1)
+                },
+            "clients": vars
+        }
         json_vars = json.dumps(vars)
         del vars
         self._logger.info("Pushing a %d bytes long json doc.", len(json_vars))

--- a/scripts/run_tracker.sh
+++ b/scripts/run_tracker.sh
@@ -63,7 +63,7 @@ if [ ! -e dispersy ]; then
     exit 1
 fi
 
-export PYTHONPATH=$PYTHONPATH:$PWD/dispersy
+export PYTHONPATH=$PYTHONPATH:$PWD:$PWD/dispersy
 
 if [ -z "$HEAD_HOST" ]; then
     HEAD_HOST=$(hostname)
@@ -98,7 +98,7 @@ while [ $EXPECTED_SUBSCRIBERS -gt 0 ] || [ $NR_TRACKERS -lt 4 ]; do
     mkdir -p $STATEDIR
     ln -s $OUTPUT_DIR/bootstraptribler.txt $STATEDIR/bootstraptribler.txt
     # Do not daemonize the process as we want to wait for all of them to die at the end of this script
-    twistd --pidfile tracker_$TRACKER_PORT.pid -n $EXTRA_ARGS --logfile="$OUTPUT_DIR/tracker_out_$TRACKER_PORT.log" tracker --port $TRACKER_PORT --crypto $TRACKER_CRYPTO $EXTRA_TRACKER_ARGS --statedir=$STATEDIR &
+    twistd --pidfile $STATEDIR/tracker_$TRACKER_PORT.pid -n $EXTRA_ARGS --logfile="$OUTPUT_DIR/tracker_out_$TRACKER_PORT.log" tracker --port $TRACKER_PORT --crypto $TRACKER_CRYPTO $EXTRA_TRACKER_ARGS --statedir=$STATEDIR &
     let TRACKER_PORT=$TRACKER_PORT+1
     let EXPECTED_SUBSCRIBERS=$EXPECTED_SUBSCRIBERS-1000
     let NR_TRACKERS=$NR_TRACKERS+1


### PR DESCRIPTION
This PR provides DHT isolation for Gumby experiments. This is usefull for experiments that expect a properly working DHT. If such experiments are run on a single node (or have many dht nodes on a few IP addresses) the experiment has a high probability to fail. This is mainly because DHT implementations (such as pymdht and libtorrent) explicitly filter local addresses in dht announce messages and allow only one node per IP. The main feature of this PR is an experiment module to change libtorrent/pymdht/tribler such that it allows both local addresses in the DHT and multiple nodes per IP. 

This PR depends on PR's in tribler and pymdht.