### PR TITLE
Fixed typo in multichain scenario

### DIFF
--- a/experiments/multichain/multichain_1000.scenario
+++ b/experiments/multichain/multichain_1000.scenario
@@ -1,7 +1,7 @@
 &module gumby.modules.tribler_module.TriblerModule
 &module experiments.multichain.multichain_module.MultichainModule
 
-@0:1 isolate_community MultichainCommunity
+@0:1 isolate_community MultiChainCommunity
 @0:2 start_session
 @0:65 set_unlimited_pending
 @0:70 start_requesting_signatures


### PR DESCRIPTION
This fixes the issue which arises in [these logs](https://jenkins.tribler.org/job/pers/job/vandenheuvel/job/Experiment_multichain_integration/5/artifact/output/localhost/node008/00000.err/*view*/).