### PR TITLE
Fixed AllChannel experiment not finding peers

### DIFF
--- a/experiments/dispersy/allchannel_module.py
+++ b/experiments/dispersy/allchannel_module.py
@@ -84,6 +84,12 @@ class AllChannelModule(CommunityExperimentModule):
 
         self._logger.info("trying-to-join-community")
 
+        if not self.community:
+            # The community class has been removed and this lc is still going
+            self._logger.error("join() not satisfied before end of experiment")
+            self.join_lc.stop()
+            return
+
         cid = self.community._channelcast_db.getChannelIdFromDispersyCID(None)
         if cid:
             community = self.community._get_channel_community(cid)

--- a/experiments/dispersy/allchannel_small.scenario
+++ b/experiments/dispersy/allchannel_small.scenario
@@ -12,5 +12,5 @@
 @0:29 reset_dispersy_statistics {5}
 @0:30 join {5}
 @0:30 publish 2 {1}
-@0:50 stop_session
-@0:55 stop
+@1:50 stop_session
+@1:55 stop

--- a/gumby/modules/base_dispersy_module.py
+++ b/gumby/modules/base_dispersy_module.py
@@ -65,8 +65,8 @@ class BaseDispersyModule(ExperimentModule):
             with open(path.join(my_state_path, 'bootstraptribler.txt'), "w+") as f:
                 f.write("\n".join(["%s %d" % (environ['HEAD_HOST'], port) for port in port_range]))
 
-
         config = TriblerConfig()
+        config.set_permid_keypair_filename("keypair_" + str(self.experiment.my_id))
         config.set_state_dir(my_state_path)
         config.set_torrent_checking_enabled(False)
         config.set_megacache_enabled(False)

--- a/gumby/modules/community_launcher.py
+++ b/gumby/modules/community_launcher.py
@@ -112,9 +112,6 @@ class DiscoveryCommunityLauncher(CommunityLauncher):
         from Tribler.dispersy.discovery.community import DiscoveryCommunity
         return DiscoveryCommunity
 
-    def get_my_member(self, dispersy, session):
-        return dispersy.get_new_member()
-
     def get_kwargs(self, session):
         return self.community_kwargs
 


### PR DESCRIPTION
Fixes #345 (also the mentioned `community = None` exception if connecting fails).

This issue turned out to be a trifecta of issues:
 - The DiscoveryCommunityLauncher used a different member than the other communities
 - The keypair file was shared between instances/peers/processes
 - The peer introduction time was too short