### PR TITLE
Fix for run_nosetest  being a string

### DIFF
--- a/scripts/run_nosetests_for_jenkins.sh
+++ b/scripts/run_nosetests_for_jenkins.sh
@@ -157,7 +157,7 @@ else
                 pids+=" $!"
                 let COUNT=1+$COUNT
             done
-            for p in $pids; do
+            for p in `echo $pids`; do
                 if wait $p; then
                     echo "Process $p success"
                 else


### PR DESCRIPTION
Fixes #347 

For some reason `$pids` is being interpreted as a delimited string on the Windows and Mac machines. This PR makes it so that if either `$pids` is equal to `  1 2 3 4` (as it should be) or `" 1 2 3 4"` (as it apparently is on the Windows and Mac machines), the for loop will work.