### PR TITLE
Check log files for process crashes on Windows/Mac

### DIFF
--- a/scripts/check_test_runner_output.sh
+++ b/scripts/check_test_runner_output.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+if [[ $# -gt 0 ]]; then
+    folder="$1"
+else
+    folder=.
+fi
+pattern=".*/[0-9]+\\.err"
+for f in `find $folder -regex $pattern`; do
+    exit_status=$(tail -1 $f | grep -o "[0-9]*")
+    if [[ ! -z $exit_status ]]; then
+        file_name=$(grep -o "/[0-9][0-9]*\.err" <<< $f)
+        proc_num=$(grep -o "[0-9][0-9]*" <<< $file_name)
+        echo "Process $proc_num failed with exit status: $exit_status!"
+        exit $exit_status
+    fi
+done

--- a/scripts/run_nosetests_for_jenkins.sh
+++ b/scripts/run_nosetests_for_jenkins.sh
@@ -156,6 +156,21 @@ else
                 let COUNT=1+$COUNT
             done
             wait
+            bash $WORKSPACE/gumby/scripts/check_test_runner_output.sh $TEST_RUNNER_OUT_DIR
+            EXIT_CODE=$?
+            if [ ! $EXIT_CODE -eq 0 ]; then
+                echo "ERROR: Process guard failed with exit code $EXIT_CODE, aborting and printing logs"
+                [ ! -z $PYLINT_PID ] && kill -3 $PYLINT_PID ||:
+                [ ! -z $SLOCCOUNT_PID ] && kill -3 $SLOCCOUNT_PID ||:
+                for LOG in $(ls -1 $TEST_RUNNER_OUT_DIR/* | sort); do
+                    echo "##vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv##"
+                    echo "## Last 20 lines of $LOG"
+                    tail -20 $LOG
+                    echo "## End of $LOG"
+                    echo "##^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^##"
+                done
+                exit 1
+            fi
         fi
     else
         echo "ERROR: NOSE_TESTS_PARALLELISATION is set but NOSE_TESTS_TO_RUN is not a directory, bailing out."


### PR DESCRIPTION
Fixes #350 

Instead of checking the spawned process exit codes, this PR checks the output logs of the test runners to determine if one of the runner crashed.