### PR TITLE
WIP: Fix gumby with new tribler config structure

### DIFF
--- a/experiments/dispersy/allchannel_module.py
+++ b/experiments/dispersy/allchannel_module.py
@@ -63,7 +63,7 @@ class AllChannelModule(CommunityExperimentModule):
 
     def on_id_received(self):
         super(AllChannelModule, self).on_id_received()
-        self.tribler_config.set_channel_search_enabled(True)
+        self.session_config.set_channel_search_enabled(True)
         self.community_launcher.community_kwargs["tribler_session"] = None
         self.community_loader.get_launcher("ChannelCommunity").community_kwargs["tribler_session"] = None
 

--- a/experiments/dispersy/hidden_services_module.py
+++ b/experiments/dispersy/hidden_services_module.py
@@ -61,12 +61,12 @@ class HiddenServicesModule(CommunityExperimentModule):
 
     def on_id_received(self):
         super(HiddenServicesModule, self).on_id_received()
-        self.tribler_config.set_tunnel_community_enabled(True)
-        self.tribler_config.set_mainline_dht_enabled(True)
-        self.tribler_config.set_libtorrent_enabled(True)
-        self.tribler_config.set_tunnel_community_socks5_listen_ports([23000 + 100 * self.my_id + i for i in range(5)])
-        self.tribler_config.set_tunnel_community_exitnode_enabled(False)
-        self.community_launcher.community_kwargs["settings"] = TunnelSettings(self.tribler_config)
+        self.session_config.set_tunnel_community_enabled(True)
+        self.session_config.set_mainline_dht_enabled(True)
+        self.session_config.set_libtorrent_enabled(True)
+        self.session_config.set_tunnel_community_socks5_listen_ports([23000 + 100 * self.my_id + i for i in range(5)])
+        self.session_config.set_tunnel_community_exitnode_enabled(False)
+        self.community_launcher.community_kwargs["settings"] = TunnelSettings(self.session)
 
     def on_dispersy_available(self, _):
         super(HiddenServicesModule, self).on_dispersy_available(_)
@@ -76,7 +76,7 @@ class HiddenServicesModule(CommunityExperimentModule):
             return 1.0, []
         self.session.set_download_states_callback(monitor_downloads, False)
 
-    # TunnelSettings should be obtained from tribler_config settings. But not all properties of the tunnel settings can
+    # TunnelSettings should be obtained from session_config settings. But not all properties of the tunnel settings can
     # be controlled that way. So we store a custom TunnelSettings object in the community launcher. Properties that have
     # a regular config option should also be set in the config object so we're consistent as far as all other code is
     # concerned.
@@ -88,7 +88,7 @@ class HiddenServicesModule(CommunityExperimentModule):
     def set_tunnel_exit(self, value):
         value = HiddenServicesModule.str2bool(value)
         self._logger.error("This peer will be exit node: %s" % ('Yes' if value else 'No'))
-        self.tribler_config.set_tunnel_community_exitnode_enabled(value)
+        self.session_config.set_tunnel_community_exitnode_enabled(value)
         self.tunnel_settings.become_exitnode = value
 
     @experiment_callback

--- a/experiments/trustchain/fullstack-small.scenario
+++ b/experiments/trustchain/fullstack-small.scenario
@@ -4,7 +4,7 @@
 &module experiments.dispersy.hidden_services_module.HiddenServicesModule
 
 @0:0 isolate_community HiddenTunnelCommunity
-@0:0 isolate_community MultiChainCommunity
+@0:0 isolate_community TriblerChainCommunity
 @0:0 isolate_dht
 
 @0:1 set_transfer_size 16777216

--- a/experiments/trustchain/logger.conf
+++ b/experiments/trustchain/logger.conf
@@ -8,7 +8,7 @@ keys=default
 keys=default
 
 [logger_root]
-level=WARNING
+level=INFO
 handlers=default
 
 [logger_TrustChainCommunity]

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -20,12 +20,12 @@ class TrustchainModule(CommunityExperimentModule):
 
     def on_id_received(self):
         super(TrustchainModule, self).on_id_received()
-        self.tribler_config.set_trustchain_enabled(True)
+        self.session_config.set_trustchain_enabled(True)
 
         # We need the trustchain key at this point. However, the configured session is not started yet. So we generate
         # the keys here and place them in the correct place. When the session starts it will load these keys.
         trustchain_keypair = permid.generate_keypair_trustchain()
-        trustchain_pairfilename = self.tribler_config.get_trustchain_permid_keypair_filename()
+        trustchain_pairfilename = self.session_config.get_trustchain_permid_keypair_filename()
         permid.save_keypair_trustchain(trustchain_keypair, trustchain_pairfilename)
         permid.save_pub_key_trustchain(trustchain_keypair, "%s.pub" % trustchain_pairfilename)
 

--- a/gumby/launch_scenario.py
+++ b/gumby/launch_scenario.py
@@ -84,6 +84,8 @@ def main(self_service=False):
 
         # create experiment service with 1 expected subscriber, and start in 0 seconds
         fact = ExperimentServiceFactory(1, 0)
+        if "PEER_ID" in environ:
+            fact.connection_counter = int(environ["PEER_ID"]) - 1
         # need to monkey patch this one or it will kill the reactor.
         fact.onExperimentStarted = exp_started
         reactor.listenTCP(int(environ['SYNC_PORT']), fact)

--- a/gumby/modules/community_launcher.py
+++ b/gumby/modules/community_launcher.py
@@ -206,6 +206,10 @@ class TrustChainCommunityLauncher(CommunityLauncher):
     def get_kwargs(self, session):
         return {}
 
+    def finalize(self, dispersy, session, community):
+        super(TrustChainCommunityLauncher, self).finalize(dispersy, session, community)
+        session.lm.tribler_chain = community
+
 
 class TriblerChainCommunityLauncher(CommunityLauncher):
 

--- a/gumby/modules/dht_module.py
+++ b/gumby/modules/dht_module.py
@@ -51,8 +51,8 @@ class DHTModule(ExperimentModule):
 
     def on_id_received(self):
         super(DHTModule, self).on_id_received()
-        self.session_config.set_mainline_dht(True)
-        self.vars["dht_node_port"] = self.session_config.get_mainline_dht_listen_port()
+        self.session_config.set_mainline_dht_enabled(True)
+        self.vars["dht_node_port"] = self.session_config.get_mainline_dht_port()
 
     def on_all_vars_received(self):
         super(DHTModule, self).on_id_received()
@@ -89,7 +89,7 @@ class DHTModule(ExperimentModule):
     @experiment_callback
     def enable_pymdht_dht(self):
         if not self.lm.mainline_dht:
-            self.lm.mainline_dht = pymdht.init(('127.0.0.1', self.session_config.get_mainline_dht_listen_port()),
+            self.lm.mainline_dht = pymdht.init(('127.0.0.1', self.session_config.get_mainline_dht_port()),
                                                self.session_config.get_state_dir())
 
     @experiment_callback

--- a/gumby/sync.py
+++ b/gumby/sync.py
@@ -167,7 +167,7 @@ class ExperimentServiceFactory(Factory):
         self.expected_subscribers = expected_subscribers
         self.experiment_start_delay = experiment_start_delay
         self.parsing_semaphore = DeferredSemaphore(500)
-        self.connection_counter = -1
+        self.connection_counter = 0
         self.connections_made = []
         self.connections_ready = []
         self.vars_received = []
@@ -179,7 +179,7 @@ class ExperimentServiceFactory(Factory):
 
     def buildProtocol(self, addr):
         self.connection_counter += 1
-        return ExperimentServiceProto(self, self.connection_counter + 1)
+        return ExperimentServiceProto(self, self.connection_counter)
 
     def setConnectionMade(self, proto):
         if not self._timeout_delayed_call:


### PR DESCRIPTION
In this pull request:
- Refactored the code that accesses dispersy(provider)/session/config to be in BaseDispersyProvider. Other experiment modules also need access to these items, and there was some duplicated code as a result of this.
- Renamed tribler_config to session_config, this should now be consistent across all gumby modules.
- Changed the CommunityExperimentModule to return the correct tribler config (instead of the old tribler-session-is-also-a-config)
- Renamed Multichain references to TriblerChain
  