### PR TITLE
WIP: Match gumby experiment client id's to process guard's log numbers

### DIFF
--- a/gumby/experiment.py
+++ b/gumby/experiment.py
@@ -84,6 +84,9 @@ class ExperimentClient(object, LineReceiver):
     def connectionMade(self):
         self._logger.debug("Connected to the experiment server")
         self.sendLine("time:%f" % time())
+        if "GUMBY_PROCESS_ID" in environ:
+            self._logger.debug("Requesting id %s", environ["GUMBY_PROCESS_ID"])
+            self.sendLine("reqid:%d" % int(environ["GUMBY_PROCESS_ID"]))
 
         self.state = "id"
 

--- a/scripts/process_guard.py
+++ b/scripts/process_guard.py
@@ -7,7 +7,7 @@ import json
 from glob import iglob
 from math import ceil
 from os import (R_OK, access, errno, getpgid, getpid, kill, killpg, makedirs, mkdir, path, setsid, sysconf,
-                sysconf_names)
+                sysconf_names, environ)
 from signal import SIGKILL, SIGTERM, signal
 from subprocess import Popen
 from time import sleep, time
@@ -172,7 +172,10 @@ class ResourceMonitor(object):
         print >> stdout, "Starting #%05d: %s" % (self.cmd_counter, cmd)
         if stdout:
             stdout.flush()
-        p = PGPopen(cmd, shell=True, stdout=stdout, stderr=stderr, close_fds=True, env=None, preexec_fn=setsid)
+
+        env = dict(environ)
+        env["GUMBY_PROCESS_ID"] = str(self.cmd_counter)
+        p = PGPopen(cmd, shell=True, stdout=stdout, stderr=stderr, close_fds=True, env=env, preexec_fn=setsid)
         self.pid_dict[p.pid] = p
         self.pgid_list.append(getpgid(p.pid))
 


### PR DESCRIPTION
I got fed up with trying to work out which log file corresponds to what experiment client. 

This PR changes the experiment server to keep a map of what IDs clients have requested. Clients that have not requested an ID get assigned one when the IDs need to be sent. Furthermore, the process guard sets an environment variable that communicates to the experiment client what its "number" is. The experiment client then uses this number to request that specific ID from the experiment server.

Note that when using more than one process guard to launch experiment clients (like on the das), all guarantees go out the window. This could be fixed in the future by adding an offset through the environment of the process guard such that each process guard sets up a disjoint block of ids.