### PR TITLE
Disabled Dispersy by default in Gumby experiments

### DIFF
--- a/experiments/dht/dht_module.py
+++ b/experiments/dht/dht_module.py
@@ -19,7 +19,6 @@ class DHTModule(IPv8OverlayExperimentModule):
 
     def on_id_received(self):
         super(DHTModule, self).on_id_received()
-        self.tribler_config.set_dispersy_enabled(False)
         self.tribler_config.set_dht_enabled(True)
         self.tribler_config.set_trustchain_enabled(False)
 

--- a/experiments/dispersy/allchannel_module.py
+++ b/experiments/dispersy/allchannel_module.py
@@ -63,6 +63,7 @@ class AllChannelModule(DispersyCommunityExperimentModule):
 
     def on_id_received(self):
         super(AllChannelModule, self).on_id_received()
+        self.tribler_config.set_dispersy_enabled(True)
         self.tribler_config.set_channel_search_enabled(True)
         self.dispersy_community_launcher.community_kwargs["tribler_session"] = None
         self.dispersy_community_loader.get_launcher("ChannelCommunity").community_kwargs["tribler_session"] = None

--- a/experiments/market/market_module.py
+++ b/experiments/market/market_module.py
@@ -31,7 +31,6 @@ class MarketModule(IPv8OverlayExperimentModule):
 
     def on_id_received(self):
         super(MarketModule, self).on_id_received()
-        self.tribler_config.set_dispersy_enabled(False)
         self.tribler_config.set_market_community_enabled(True)
 
     def on_dispersy_available(self, dispersy):

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -20,7 +20,6 @@ class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
 
     def on_id_received(self):
         super(TrustchainModule, self).on_id_received()
-        self.tribler_config.set_dispersy_enabled(False)
 
         # We need the trustchain key at this point. However, the configured session is not started yet. So we generate
         # the keys here and place them in the correct place. When the session starts it will load these keys.

--- a/experiments/tunnels/tunnel_module.py
+++ b/experiments/tunnels/tunnel_module.py
@@ -57,7 +57,6 @@ class TunnelModule(IPv8OverlayExperimentModule):
 
     def on_id_received(self):
         super(TunnelModule, self).on_id_received()
-        self.tribler_config.set_dispersy_enabled(False)
         self.tribler_config.set_tunnel_community_enabled(True)
         self.tribler_config.set_mainline_dht_enabled(True)
         self.tribler_config.set_libtorrent_enabled(True)

--- a/gumby/modules/base_dispersy_module.py
+++ b/gumby/modules/base_dispersy_module.py
@@ -89,7 +89,7 @@ class BaseDispersyModule(ExperimentModule):
         config.set_state_dir(my_state_path)
         config.set_torrent_checking_enabled(False)
         config.set_megacache_enabled(False)
-        config.set_dispersy_enabled(True)
+        config.set_dispersy_enabled(False)
         config.set_market_community_enabled(False)
         config.set_mainline_dht_enabled(False)
         config.set_mainline_dht_port(18000 + self.my_id)


### PR DESCRIPTION
So it doesn't slow down experiments if we forgot to disable it...