### PR TITLE
Various improvements to TrustChain experiments

### DIFF
--- a/experiments/ipv8/discovery_module.py
+++ b/experiments/ipv8/discovery_module.py
@@ -19,7 +19,6 @@ class DiscoveryModule(IPv8OverlayExperimentModule):
     def on_id_received(self):
         super(DiscoveryModule, self).on_id_received()
         self.tribler_config.set_ipv8_discovery(True)
-        self.tribler_config.set_trustchain_enabled(False)
 
     def on_dispersy_available(self, dispersy):
         # Disable threadpool messages

--- a/experiments/ipv8/discovery_module.py
+++ b/experiments/ipv8/discovery_module.py
@@ -24,10 +24,3 @@ class DiscoveryModule(IPv8OverlayExperimentModule):
     def on_dispersy_available(self, dispersy):
         # Disable threadpool messages
         self.overlay._use_main_thread = True
-
-    @experiment_callback
-    def introduce_some_peers(self, num_peers):
-        rand_peer_ids = random.sample(self.all_vars.keys(), int(num_peers))
-        for rand_peer_id in rand_peer_ids:
-            self._logger.info("Walking initially to peer %s", rand_peer_id)
-            self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(rand_peer_id))

--- a/experiments/ipv8/ipv8_walking.scenario
+++ b/experiments/ipv8/ipv8_walking.scenario
@@ -4,7 +4,7 @@
 @0:1 start_session
 @0:1 annotate start-experiment
 @0:2 start_ipv8_statistics_monitor
-@0:5 introduce_some_peers 10
+@0:5 introduce_peers 10
 @0:60 stop_session
 @0:65 write_overlay_statistics
 @0:67 stop

--- a/experiments/ipv8/parse_ipv8_statistics.py
+++ b/experiments/ipv8/parse_ipv8_statistics.py
@@ -100,8 +100,34 @@ class IPv8StatisticsParser(StatisticsParser):
                                                                msg_stats['num_down'], msg_stats['bytes_up'],
                                                                msg_stats['bytes_down']))
 
+    def aggregate_peer_connections(self):
+        peers_connections = set()
+
+        for peer_nr, filename, dir in self.yield_files('verified_peers.txt'):
+            peer_connections = [line.rstrip('\n') for line in open(filename)]
+            for peer_connection in peer_connections:
+                peers_connections.add((peer_nr, int(peer_connection)))
+
+        with open('peer_connections.log', 'w', 0) as connections_file:
+            connections_file.write("peer_a,peer_b\n")
+            for peer_a, peer_b in peers_connections:
+                connections_file.write("%d,%d\n" % (peer_a, peer_b))
+
+    def aggregate_bandwidth(self):
+        total_up, total_down = 0, 0
+        for peer_nr, filename, dir in self.yield_files('bandwidth.txt'):
+            with open(filename) as bandwidth_file:
+                parts = bandwidth_file.read().rstrip('\n').split(",")
+                total_up += int(parts[0])
+                total_down += int(parts[1])
+
+        with open('total_bandwidth.log', 'w', 0) as output_file:
+            output_file.write("%s,%s,%s\n" % (total_up, total_down, (total_up + total_down) / 2))
+
     def run(self):
         self.aggregate_messages()
+        self.aggregate_peer_connections()
+        self.aggregate_bandwidth()
 
 if __name__ == "__main__":
     # cd to the output directory

--- a/experiments/market/parse_market_statistics.py
+++ b/experiments/market/parse_market_statistics.py
@@ -50,30 +50,6 @@ class MarketStatisticsParser(StatisticsParser):
             transactions_file.write("time,transactions\n")
             transactions_file.write(transactions_cumulative_str)
 
-    def aggregate_peer_connections(self):
-        peers_connections = set()
-
-        for peer_nr, filename, dir in self.yield_files('verified_peers.txt'):
-            peer_connections = [line.rstrip('\n') for line in open(filename)]
-            for peer_connection in peer_connections:
-                peers_connections.add((peer_nr, int(peer_connection)))
-
-        with open('peer_connections.log', 'w', 0) as connections_file:
-            connections_file.write("peer_a,peer_b\n")
-            for peer_a, peer_b in peers_connections:
-                connections_file.write("%d,%d\n" % (peer_a, peer_b))
-
-    def aggregate_bandwidth(self):
-        total_up, total_down = 0, 0
-        for peer_nr, filename, dir in self.yield_files('bandwidth.txt'):
-            with open(filename) as bandwidth_file:
-                parts = bandwidth_file.read().rstrip('\n').split(",")
-                total_up += int(parts[0])
-                total_down += int(parts[1])
-
-        with open('total_bandwidth.log', 'w', 0) as taxi_file:
-            taxi_file.write("%s,%s,%s\n" % (total_up, total_down, (total_up + total_down) / 2))
-
     def aggregate_order_data(self):
         """
         Aggregate all data of the orders
@@ -140,10 +116,8 @@ class MarketStatisticsParser(StatisticsParser):
 
     def run(self):
         self.aggregate_transaction_data()
-        self.aggregate_peer_connections()
         self.aggregate_order_data()
         self.aggregate_general_stats()
-        self.aggregate_bandwidth()
 
 
 # cd to the output directory

--- a/experiments/trustchain/trustchain.conf
+++ b/experiments/trustchain/trustchain.conf
@@ -46,4 +46,4 @@ sync_port = __unique_port__
 
 tracker_port = __unique_port__
 
-extra_r_scripts_to_run = "trustchain.r"
+extra_r_scripts_to_run = "trustchain.r plot_connections.r"

--- a/experiments/trustchain/trustchain_basic.scenario
+++ b/experiments/trustchain/trustchain_basic.scenario
@@ -5,9 +5,9 @@
 @0:2 start_session
 @0:5 init_trustchain
 @0:10 introduce_peers
-@0:70 start_requesting_signatures
-@0:130 stop_requesting_signatures
-@0:138 write_overlay_statistics
-@0:138 write_trustchain_statistics
-@0:140 stop_session
-@0:150 stop
+@0:30 start_requesting_signatures
+@0:90 stop_requesting_signatures
+@0:95 write_overlay_statistics
+@0:95 write_trustchain_statistics
+@0:97 stop_session
+@0:100 stop

--- a/experiments/trustchain/trustchain_basic.scenario
+++ b/experiments/trustchain/trustchain_basic.scenario
@@ -10,5 +10,6 @@
 @0:90 stop_requesting_signatures
 @0:95 write_overlay_statistics
 @0:95 write_trustchain_statistics
-@0:97 stop_session
-@0:100 stop
+@0:95 commit_blocks_to_db
+@0:100 stop_session
+@0:105 stop

--- a/experiments/trustchain/trustchain_basic.scenario
+++ b/experiments/trustchain/trustchain_basic.scenario
@@ -5,6 +5,7 @@
 @0:2 start_session
 @0:5 init_trustchain
 @0:10 introduce_peers
+@0:30 annotate start-creating-blocks
 @0:30 start_requesting_signatures
 @0:90 stop_requesting_signatures
 @0:95 write_overlay_statistics

--- a/experiments/trustchain/trustchain_crawl.scenario
+++ b/experiments/trustchain/trustchain_crawl.scenario
@@ -4,6 +4,7 @@
 
 @0:2 start_session
 @0:5 init_trustchain
+@0:5 set_validation_range 1
 @0:10 introduce_peers max_peers=10 excluded_peers=1
 @0:10 add_walking_strategy RandomWalk -1 {1}
 @0:11 introduce_peers max_peers=1 {1}

--- a/experiments/trustchain/trustchain_crawl.scenario
+++ b/experiments/trustchain/trustchain_crawl.scenario
@@ -8,8 +8,10 @@
 @0:10 add_walking_strategy RandomWalk -1 {1}
 @0:11 introduce_peers max_peers=1 {1}
 @0:30 annotate start-creating-blocks
+@0:30 start_monitor_num_blocks_in_db {1}
 @0:30 start_requesting_signatures
 @0:90 stop_requesting_signatures
+@0:95 stop_monitor_num_blocks_in_db {1}
 @0:95 write_overlay_statistics
 @0:95 commit_blocks_to_db
 @0:117 stop_session

--- a/experiments/trustchain/trustchain_crawl.scenario
+++ b/experiments/trustchain/trustchain_crawl.scenario
@@ -9,6 +9,6 @@
 @0:30 start_requesting_signatures
 @0:90 stop_requesting_signatures
 @0:95 write_overlay_statistics
-@0:95 write_trustchain_statistics
-@0:97 stop_session
-@0:100 stop
+@0:95 commit_blocks_to_db
+@0:117 stop_session
+@0:127 stop

--- a/experiments/trustchain/trustchain_crawl.scenario
+++ b/experiments/trustchain/trustchain_crawl.scenario
@@ -5,6 +5,7 @@
 @0:2 start_session
 @0:5 init_trustchain
 @0:5 set_validation_range 1
+@0:5 enable_crawler {1}
 @0:10 introduce_peers max_peers=10 excluded_peers=1
 @0:10 add_walking_strategy RandomWalk -1 {1}
 @0:11 introduce_peers max_peers=1 {1}

--- a/experiments/trustchain/trustchain_crawl.scenario
+++ b/experiments/trustchain/trustchain_crawl.scenario
@@ -5,6 +5,8 @@
 @0:2 start_session
 @0:5 init_trustchain
 @0:10 introduce_peers max_peers=10 excluded_peers=1
+@0:10 add_walking_strategy RandomWalk -1 {1}
+@0:11 introduce_peers max_peers=1 {1}
 @0:30 annotate start-creating-blocks
 @0:30 start_requesting_signatures
 @0:90 stop_requesting_signatures

--- a/experiments/trustchain/trustchain_crawl.scenario
+++ b/experiments/trustchain/trustchain_crawl.scenario
@@ -1,10 +1,10 @@
 &module gumby.modules.tribler_module.TriblerModule
+&module experiments.ipv8.discovery_module.DiscoveryModule
 &module experiments.trustchain.trustchain_module.TrustchainModule
 
-@0:1 isolate_ipv8_overlay TrustChainCommunity
 @0:2 start_session
 @0:5 init_trustchain
-@0:10 introduce_peers max_peers=10
+@0:10 introduce_peers max_peers=10 excluded_peers=1
 @0:30 annotate start-creating-blocks
 @0:30 start_requesting_signatures
 @0:90 stop_requesting_signatures

--- a/experiments/trustchain/trustchain_mem_db.py
+++ b/experiments/trustchain/trustchain_mem_db.py
@@ -1,0 +1,127 @@
+from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock
+
+
+class TrustchainMemoryDatabase(object):
+    """
+    This class defines an optimized memory database for TrustChain.
+    """
+
+    def __init__(self, working_directory, db_name):
+        self.working_directory = working_directory
+        self.db_name = db_name
+        self.block_cache = {}
+        self.linked_block_cache = {}
+        self.block_types = {}
+        self.latest_blocks = {}
+        self.original_db = None
+
+    def get_block_class(self, block_type):
+        """
+        Get the block class for a specific block type.
+        """
+        if block_type not in self.block_types:
+            return TrustChainBlock
+
+        return self.block_types[block_type]
+
+    def add_block(self, block):
+        self.block_cache[(block.public_key, block.sequence_number)] = block
+        self.linked_block_cache[(block.link_public_key, block.link_sequence_number)] = block
+
+        if block.public_key not in self.latest_blocks:
+            self.latest_blocks[block.public_key] = block
+        elif self.latest_blocks[block.public_key].sequence_number < block.sequence_number:
+            self.latest_blocks[block.public_key] = block
+
+    def remove_block(self, block):
+        self.block_cache.pop((block.public_key, block.sequence_number), None)
+        self.linked_block_cache.pop((block.link_public_key, block.link_sequence_number), None)
+
+    def get(self, public_key, sequence_number):
+        if (public_key, sequence_number) in self.block_cache:
+            return self.block_cache[(public_key, sequence_number)]
+        return None
+
+    def get_all_blocks(self):
+        return self.block_cache.values()
+
+    def get_number_of_known_blocks(self, public_key=None):
+        if public_key:
+            return len([pk for pk, _ in self.block_cache.iterkeys() if pk == public_key])
+        return len(self.block_cache.keys())
+
+    def contains(self, block):
+        return (block.public_key, block.sequence_number) in self.block_cache
+
+    def get_latest(self, public_key, block_type=None):
+        # TODO for now we assume block_type is None
+        if public_key in self.latest_blocks:
+            return self.latest_blocks[public_key]
+        return None
+
+    def get_block_after(self, block, block_type=None):
+        # TODO for now we assume block_type is None
+        if (block.public_key, block.sequence_number + 1) in self.block_cache:
+            return self.block_cache[(block.public_key, block.sequence_number + 1)]
+        return None
+
+    def get_block_before(self, block, block_type=None):
+        # TODO for now we assume block_type is None
+        if (block.public_key, block.sequence_number - 1) in self.block_cache:
+            return self.block_cache[(block.public_key, block.sequence_number - 1)]
+        return None
+
+    def get_lowest_sequence_number_unknown(self, public_key):
+        if public_key not in self.latest_blocks:
+            return 1
+        latest_seq_num = self.latest_blocks[public_key].sequence_number
+        for ind in xrange(1, latest_seq_num + 1):
+            if (public_key, ind + 1) not in self.block_cache:
+                return ind
+
+    def get_lowest_range_unknown(self, public_key):
+        lowest_unknown = self.get_lowest_sequence_number_unknown(public_key)
+        known_block_nums = [seq_num for pk, seq_num in self.block_cache.iterkeys() if pk == public_key]
+        filtered_block_nums = [seq_num for seq_num in known_block_nums if seq_num > lowest_unknown]
+        if filtered_block_nums:
+            return lowest_unknown, filtered_block_nums[0] - 1
+        else:
+            return lowest_unknown, lowest_unknown
+
+    def get_linked(self, block):
+        if (block.link_public_key, block.link_sequence_number) in self.block_cache:
+            return self.block_cache[(block.link_public_key, block.link_sequence_number)]
+        if (block.public_key, block.sequence_number) in self.linked_block_cache:
+            return self.linked_block_cache[(block.public_key, block.sequence_number)]
+        return None
+
+    def crawl(self, public_key, start_seq_num, end_seq_num, limit=100):
+        # TODO we assume only ourselves are crawled
+        blocks = []
+        orig_blocks_added = 0
+        for seq_num in xrange(start_seq_num, end_seq_num + 1):
+            if (public_key, seq_num) in self.block_cache:
+                block = self.block_cache[(public_key, seq_num)]
+                blocks.append(block)
+                orig_blocks_added += 1
+                linked_block = self.get_linked(block)
+                if linked_block:
+                    blocks.append(linked_block)
+
+            if orig_blocks_added >= limit:
+                break
+
+        return blocks
+
+    def commit(self, my_pub_key):
+        """
+        Commit all information to the original database.
+        """
+        if self.original_db:
+            my_blocks = [block for block in self.block_cache.itervalues() if block.public_key == my_pub_key]
+            for block in my_blocks:
+                self.original_db.add_block(block)
+
+    def close(self):
+        if self.original_db:
+            self.original_db.close()

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -51,6 +51,10 @@ class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
         self.tribler_config.set_trustchain_memory_db(True)
 
     @experiment_callback
+    def set_validation_range(self, value):
+        self.overlay.settings.validation_range = int(value)
+
+    @experiment_callback
     def start_requesting_signatures(self):
         self.request_signatures_lc = LoopingCall(self.request_random_signature)
         self.request_signatures_lc.start(1)

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -18,7 +18,7 @@ from twisted.internet.task import LoopingCall
 class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
     def __init__(self, experiment):
         super(TrustchainModule, self).__init__(experiment, TrustChainCommunity)
-        self.request_signatures_lc = LoopingCall(self.request_random_signature)
+        self.request_signatures_lc = None
 
     def on_id_received(self):
         super(TrustchainModule, self).on_id_received()
@@ -42,6 +42,7 @@ class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
 
     @experiment_callback
     def start_requesting_signatures(self):
+        self.request_signatures_lc = LoopingCall(self.request_random_signature)
         self.request_signatures_lc.start(1)
 
     @experiment_callback

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -32,6 +32,10 @@ class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
 
         self.vars['trustchain_public_key'] = trustchain_keypair.pub().key_to_bin().encode("base64")
 
+    def on_dispersy_available(self, dispersy):
+        # Disable threadpool messages
+        self.overlay._use_main_thread = True
+
     def get_peer_public_key(self, peer_id):
         # override the default implementation since we use the trustchain key here.
         return self.all_vars[peer_id]['trustchain_public_key']

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -45,6 +45,10 @@ class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
         self.overlay.add_listener(self, ['test'])
 
     @experiment_callback
+    def enable_trustchain_memory_db(self):
+        self.tribler_config.set_trustchain_memory_db(True)
+
+    @experiment_callback
     def start_requesting_signatures(self):
         self.request_signatures_lc = LoopingCall(self.request_random_signature)
         self.request_signatures_lc.start(1)
@@ -89,6 +93,11 @@ class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
 
     def received_block(self, block):
         pass
+
+    @experiment_callback
+    def commit_blocks_to_db(self):
+        if self.session.config.use_trustchain_memory_db():
+            self.overlay.persistence.commit(self.overlay.my_peer.public_key.key_to_bin())
 
     @experiment_callback
     def write_trustchain_statistics(self):

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -55,6 +55,10 @@ class TrustchainModule(IPv8OverlayExperimentModule, BlockListener):
         self.overlay.settings.validation_range = int(value)
 
     @experiment_callback
+    def enable_crawler(self):
+        self.overlay.settings.crawler = True
+
+    @experiment_callback
     def start_requesting_signatures(self):
         self.request_signatures_lc = LoopingCall(self.request_random_signature)
         self.request_signatures_lc.start(1)

--- a/gumby/gumby_tribler_config.py
+++ b/gumby/gumby_tribler_config.py
@@ -11,6 +11,7 @@ class GumbyTriblerConfig(TriblerConfig):
         super(GumbyTriblerConfig, self).__init__(config=config)
 
         self.config['trustchain']['enabled'] = True
+        self.config['trustchain']['memory_db'] = False
         self.config['ipv8']['discovery'] = False
 
     def set_ipv8_discovery(self, value):
@@ -18,3 +19,9 @@ class GumbyTriblerConfig(TriblerConfig):
 
     def get_ipv8_discovery(self):
         return self.config['ipv8']['discovery']
+
+    def set_trustchain_memory_db(self, value):
+        self.config['trustchain']['memory_db'] = value
+
+    def use_trustchain_memory_db(self):
+        return self.config['trustchain']['memory_db']

--- a/gumby/modules/community_experiment_module.py
+++ b/gumby/modules/community_experiment_module.py
@@ -2,6 +2,8 @@ from random import sample
 from time import time
 
 from Tribler.pyipv8.ipv8.peer import Peer
+from Tribler.pyipv8.ipv8.peerdiscovery.churn import RandomChurn
+from Tribler.pyipv8.ipv8.peerdiscovery.discovery import EdgeWalk, RandomWalk
 
 from gumby.experiment import experiment_callback
 from gumby.modules.base_dispersy_module import BaseDispersyModule
@@ -222,6 +224,22 @@ class IPv8OverlayExperimentModule(ExperimentModule):
             rand_peer_ids = sample(eligible_peers, int(max_peers))
             for rand_peer_id in rand_peer_ids:
                 self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(rand_peer_id))
+
+    @experiment_callback
+    def add_walking_strategy(self, name, max_peers, **kwargs):
+        if name not in ['RandomWalk', 'EdgeWalk', 'RandomChurn']:
+            self._logger.warning("Strategy %s not found!", name)
+            return
+
+        strategy = None
+        if name == 'RandomWalk':
+            strategy = RandomWalk(self.overlay, **kwargs)
+        elif name == 'EdgeWalk':
+            strategy = EdgeWalk(self.overlay, **kwargs)
+        elif name == 'RandomChurn':
+            strategy = RandomChurn(self.overlay, **kwargs)
+
+        self.session.lm.ipv8.strategies.append((strategy, max_peers))
 
     def get_peer(self, peer_id):
         target = self.all_vars[peer_id]

--- a/gumby/modules/community_experiment_module.py
+++ b/gumby/modules/community_experiment_module.py
@@ -1,3 +1,4 @@
+from random import sample
 from time import time
 
 from Tribler.pyipv8.ipv8.peer import Peer
@@ -196,11 +197,31 @@ class IPv8OverlayExperimentModule(ExperimentModule):
         return None
 
     @experiment_callback
-    def introduce_peers(self):
-        # bootstrap the peer introduction, ensuring everybody knows everybody to start off with.
-        for peer_id in self.all_vars.iterkeys():
-            if int(peer_id) != self.my_id:
-                self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(peer_id))
+    def introduce_peers(self, max_peers=None, excluded_peers=None):
+        """
+        Introduce peers to each other.
+        :param max_peers: If specified, this peer will walk to this number of peers at most.
+        :param excluded_peers: If specified, this method will ignore a specific peer from the introductions.
+        """
+        excluded_peers_list = []
+        if excluded_peers:
+            excluded_peers_list = [int(excluded_peer) for excluded_peer in excluded_peers.split(",")]
+
+        if self.my_id in excluded_peers_list:
+            self._logger.info("Not participating in the peer introductions!")
+            return
+
+        if not max_peers:
+            # bootstrap the peer introduction, ensuring everybody knows everybody to start off with.
+            for peer_id in self.all_vars.iterkeys():
+                if int(peer_id) != self.my_id and int(peer_id) not in excluded_peers_list:
+                    self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(peer_id))
+        else:
+            # Walk to a number of peers
+            eligible_peers = [peer_id for peer_id in self.all_vars.keys() if int(peer_id) not in excluded_peers_list]
+            rand_peer_ids = sample(eligible_peers, int(max_peers))
+            for rand_peer_id in rand_peer_ids:
+                self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(rand_peer_id))
 
     def get_peer(self, peer_id):
         target = self.all_vars[peer_id]

--- a/gumby/modules/community_launcher.py
+++ b/gumby/modules/community_launcher.py
@@ -288,6 +288,14 @@ class TrustChainCommunityLauncher(IPv8CommunityLauncher):
         super(TrustChainCommunityLauncher, self).finalize(dispersy, session, community)
         session.lm.trustchain_community = community
 
+        # If we're using a memory DB, replace the existing one
+        if session.config.use_trustchain_memory_db():
+            orig_db = community.persistence
+
+            from experiments.trustchain.trustchain_mem_db import TrustchainMemoryDatabase
+            community.persistence = TrustchainMemoryDatabase(session.config.get_state_dir(), 'trustchain')
+            community.persistence.original_db = orig_db
+
 
 class MarketCommunityLauncher(IPv8CommunityLauncher):
 

--- a/gumby/modules/community_launcher.py
+++ b/gumby/modules/community_launcher.py
@@ -160,7 +160,7 @@ class IPv8CommunityLauncher(CommunityLauncher):
         Get walk strategies for this class.
         It should be provided as a list of tuples with the class, kwargs and maximum number of peers.
         """
-        return [(RandomWalk, {}, 20)]
+        return []
 
 
 # Dispersy communities

--- a/gumby/modules/tribler_module.py
+++ b/gumby/modules/tribler_module.py
@@ -68,6 +68,10 @@ class TriblerModule(BaseDispersyModule):
     def stop_session(self):
         deferToThread(self.session.shutdown)
 
+        # Write away the start time of the experiment
+        with open('start_time.txt', 'w') as start_time_time:
+            start_time_time.write("%f" % self.experiment.scenario_runner.exp_start_time)
+
     @experiment_callback
     def set_transfer_size(self, size):
         self.transfer_size = long(size)

--- a/scripts/post_process_trustchain.sh
+++ b/scripts/post_process_trustchain.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 gumby/experiments/trustchain/post_process_trustchain.py .
 
-graph_process_guard_data.sh
+# Invoke the IPv8 experiment process which will also plot our TrustChain statistics
+post_process_ipv8_experiment.sh


### PR DESCRIPTION
In this PR, I made various improvements to the TrustChain experiments. I also made a few minor QoL changes.
- Each node now writes away the start time of an experiment (this can be used during post-processing).
- Improved existing TrustChain experiment.
- Added crawler experiment that deploys a walking peer to crawl TrustChain blocks.
- Plotting the total number of TrustChain blocks over time.
- Disabled walker in experiments by default.
- Added a memory database (this comes in handy when doing an experiment that requires low-latency queries for blocks).
- Added a few callbacks to `TrustChainModule` for changing various settings.
- Made it possible to dynamically add new walking strategies to an experiment.
- Added an optional limit parameter to the `introduce_peers` callback.