### PR TITLE
Reduce the PyLint directives required when using six.moves

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -112,6 +112,10 @@ additional-builtins=
 # name must start or end with one of those strings.
 callbacks=cb_,_cb,on_
 
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves
+
 
 [TYPECHECK]
 


### PR DESCRIPTION
Add __redefining-builtins-modules=six.moves__ to the __VARIABLES__ section of the _build_ repo's __.pylintrc__  Related to Tribler/tribler#4122