### PR TITLE
Fixed DHT experiment

### DIFF
--- a/gumby/modules/community_launcher.py
+++ b/gumby/modules/community_launcher.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
 
-from Tribler.Core.DecentralizedTracking.dht_provider import MainlineDHTProvider
 from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
 from Tribler.pyipv8.ipv8.dht.provider import DHTCommunityProvider
 from Tribler.pyipv8.ipv8.peer import Peer
@@ -259,8 +258,6 @@ class TriblerTunnelCommunityLauncher(IPv8CommunityLauncher):
         kwargs = super(TriblerTunnelCommunityLauncher, self).get_kwargs(session)
         if session.config.get_dht_enabled():
             kwargs['dht_provider'] = DHTCommunityProvider(session.lm.dht_community, session.config.get_dispersy_port())
-        else:
-            kwargs['dht_provider'] = MainlineDHTProvider(session.lm.mainline_dht, session.config.get_dispersy_port())
         kwargs['bandwidth_wallet'] = TrustchainWallet(session.lm.trustchain_community)
         return kwargs
 

--- a/gumby/modules/dht_module.py
+++ b/gumby/modules/dht_module.py
@@ -1,15 +1,12 @@
 """
 The dht module aims to provide DHT isolation for experiments, and provide dht related utility experiment callbacks.
 """
-from random import sample
-
 from gumby.experiment import experiment_callback
 
 from gumby.modules.experiment_module import static_module, ExperimentModule
 from gumby.modules.base_dispersy_module import BaseDispersyModule
 from gumby.modules.tribler_module import TriblerModule
 
-from Tribler.Core.DecentralizedTracking.pymdht.core.routing_table import Bucket
 import Tribler.Core.Libtorrent.LibtorrentMgr as lt
 
 


### PR DESCRIPTION
We removed pymdht in Tribler so we should also remove its reference in Gumby.

Verified to work [here](https://jenkins-ci.tribler.org/job/validation_experiments/job/validation_experiment_market/217/) and [here](https://jenkins-ci.tribler.org/job/validation_experiments/job/validation_experiment_dht/200/).