### PR TITLE
Made procfs optional

### DIFF
--- a/run.py
+++ b/run.py
@@ -91,10 +91,6 @@ if __name__ == '__main__':
             print("Error: The specified configuration file doesn't exist.")
             exit(1)
 
-        if not exists('/proc'):
-            print("Error: procfs not available on this system.")
-            exit(5)
-
         # Create a process group so we can clean up after ourselves when
         setpgrp()  # create new process group and become its leader
         # Catch SIGTERM to attempt to clean after ourselves

--- a/scripts/extract_process_guard_stats.py
+++ b/scripts/extract_process_guard_stats.py
@@ -102,7 +102,7 @@ def parse_resource_files(input_directory, output_directory, start_timestamp=None
             for line in h_records:
                 parts = line.split()
 
-                if start_timestamp == None:
+                if start_timestamp is None:
                     start_timestamp = float(parts[0])
                 max_timestamp = max(max_timestamp, float(parts[0]))
                 time = float(parts[0]) - start_timestamp


### PR DESCRIPTION
If procfs is not available, we return zeros. This makes it possible to run Gumby on Mac and/or Windows.

The procfs stats on Linux are still working, as indicated by the integration test that runs as part of this PR.

Fixes #253