### PR TITLE
Partially made Gumby Python 3 compatible

### DIFF
--- a/experiments/dht/dht_module.py
+++ b/experiments/dht/dht_module.py
@@ -29,7 +29,7 @@ class DHTModule(IPv8OverlayExperimentModule):
 
     @experiment_callback
     def introduce_peers_dht(self):
-        for peer_id in self.all_vars.iterkeys():
+        for peer_id in self.all_vars.keys():
             if int(peer_id) != self.my_id:
                 self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(peer_id))
 

--- a/experiments/dht/parse_dht_statistics.py
+++ b/experiments/dht/parse_dht_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import os
 import sys
 

--- a/experiments/dht/parse_dht_statistics.py
+++ b/experiments/dht/parse_dht_statistics.py
@@ -13,7 +13,7 @@ class DHTStatisticsParser(StatisticsParser):
     """
 
     def aggregate_dht_response_times(self):
-        with open('dht_response_times.csv', 'w', 0) as csv_fp:
+        with open('dht_response_times.csv', 'w') as csv_fp:
             csv_fp.write('peer time operation response_time\n')
             for peer_nr, filename, dir in self.yield_files('dht.log'):
                 with open(filename) as log_fp:

--- a/experiments/dummy/dummy_experiment_client.py
+++ b/experiments/dummy/dummy_experiment_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # experiment_client.py ---
 #
 # Filename: experiment_client.py

--- a/experiments/gigachannel/gigachannel_module.py
+++ b/experiments/gigachannel/gigachannel_module.py
@@ -36,7 +36,7 @@ class GigaChannelModule(IPv8OverlayExperimentModule):
 
     @experiment_callback
     def introduce_peers_gigachannels(self):
-        for peer_id in self.all_vars.iterkeys():
+        for peer_id in self.all_vars.keys():
             if int(peer_id) != self.my_id:
                 self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(peer_id))
 

--- a/experiments/ipv8/parse_ipv8_statistics.py
+++ b/experiments/ipv8/parse_ipv8_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import json
 import os
 import sys

--- a/experiments/ipv8/parse_ipv8_statistics.py
+++ b/experiments/ipv8/parse_ipv8_statistics.py
@@ -39,8 +39,8 @@ class IPv8StatisticsParser(StatisticsParser):
             # Aggregate statistics for all available overlays
             for stat_time, stat_dict in stat_dicts:
                 collapsed_stat_dict = {}
-                for _, msg_stats_dict in stat_dict.iteritems():
-                    for msg_id, specific_msg_stats_dict in msg_stats_dict.iteritems():
+                for _, msg_stats_dict in stat_dict.items():
+                    for msg_id, specific_msg_stats_dict in msg_stats_dict.items():
                         if msg_id not in collapsed_stat_dict:
                             collapsed_stat_dict[msg_id] = {'num_up': 0, 'num_down': 0, 'bytes_up': 0, 'bytes_down': 0}
                         collapsed_stat_dict[msg_id]['num_up'] += specific_msg_stats_dict['num_up']
@@ -54,11 +54,11 @@ class IPv8StatisticsParser(StatisticsParser):
         # Find the largest time across all the files + different messages we have
         msg_ids = set()
         largest_time = 0
-        for stat_lists in stats_per_peer.itervalues():
+        for stat_lists in stats_per_peer.values():
             for stat_time, stat_dict in stat_lists:
                 if stat_time > largest_time:
                     largest_time = stat_time
-                for msg_id in stat_dict.iterkeys():
+                for msg_id in stat_dict.keys():
                     msg_ids.add(msg_id)
 
         if not msg_ids:
@@ -78,14 +78,14 @@ class IPv8StatisticsParser(StatisticsParser):
         # We now actually fill in the results
         for ind in xrange(1, largest_time / 5 + 1):
             cur_time = ind * 5
-            for stats_list in stats_per_peer.itervalues():
+            for stats_list in stats_per_peer.values():
                 filtered_dicts = [stat_dict for stat_time, stat_dict in stats_list if stat_time <= cur_time]
                 if not filtered_dicts:
                     continue
                 required_dict = filtered_dicts[-1]
 
                 # We have to merge the information now
-                for msg_id, msg_stats in required_dict.iteritems():
+                for msg_id, msg_stats in required_dict.items():
                     results[ind][msg_id]['num_up'] += msg_stats['num_up']
                     results[ind][msg_id]['num_down'] += msg_stats['num_down']
                     results[ind][msg_id]['bytes_up'] += msg_stats['bytes_up']
@@ -96,7 +96,7 @@ class IPv8StatisticsParser(StatisticsParser):
             output_file.write("time,msg_id,num_up,num_down,bytes_up,bytes_down\n")
             for ind, stats in enumerate(results):
                 cur_time = ind * 5
-                for msg_id, msg_stats in stats.iteritems():
+                for msg_id, msg_stats in stats.items():
                     output_file.write("%d,%s,%d,%d,%d,%d\n" % (cur_time, msg_id, msg_stats['num_up'],
                                                                msg_stats['num_down'], msg_stats['bytes_up'],
                                                                msg_stats['bytes_down']))
@@ -109,7 +109,7 @@ class IPv8StatisticsParser(StatisticsParser):
             for peer_connection in peer_connections:
                 peers_connections.add((peer_nr, int(peer_connection)))
 
-        with open('peer_connections.log', 'w', 0) as connections_file:
+        with open('peer_connections.log', 'w') as connections_file:
             connections_file.write("peer_a,peer_b\n")
             for peer_a, peer_b in peers_connections:
                 connections_file.write("%d,%d\n" % (peer_a, peer_b))
@@ -122,7 +122,7 @@ class IPv8StatisticsParser(StatisticsParser):
                 total_up += int(parts[0])
                 total_down += int(parts[1])
 
-        with open('total_bandwidth.log', 'w', 0) as output_file:
+        with open('total_bandwidth.log', 'w') as output_file:
             output_file.write("%s,%s,%s\n" % (total_up, total_down, (total_up + total_down) / 2))
 
     def aggregate_autoplot(self):

--- a/experiments/market/market_experiment.conf
+++ b/experiments/market/market_experiment.conf
@@ -25,7 +25,7 @@ das4_node_timeout = 120
 das4_instances_to_run = 1
 
 # What command do we want to run?
-das4_node_command = "launch_scenario.py"
+das4_node_command = "launch_scenario_py3.py"
 scenario_file = "market_experiment_100.scenario"
 
 messages_to_plot = 'ask,bid'

--- a/experiments/market/parse_market_statistics.py
+++ b/experiments/market/parse_market_statistics.py
@@ -42,7 +42,7 @@ class MarketStatisticsParser(StatisticsParser):
             total_transactions += 1
             transactions_cumulative_str += str(transaction_time) + "," + str(total_transactions) + "\n"
 
-        with open('transactions.log', 'w', 0) as transactions_file:
+        with open('transactions.log', 'w') as transactions_file:
             transactions_file.write("time,price,quantity,payments,peer1,peer2\n")
             transactions_file.write(transactions_str)
 
@@ -63,7 +63,7 @@ class MarketStatisticsParser(StatisticsParser):
                 orders_str += orders_data
                 orders_data_all += orders_data
 
-        with open('orders.log', 'w', 0) as orders_file:
+        with open('orders.log', 'w') as orders_file:
             orders_file.write(orders_str)
 
         # Calculate the average order latency
@@ -104,7 +104,7 @@ class MarketStatisticsParser(StatisticsParser):
                 fulfilled_asks += stats_dict['fulfilled_asks']
                 fulfilled_bids += stats_dict['fulfilled_bids']
 
-        with open('aggregated_market_stats.log', 'w', 0) as stats_file:
+        with open('aggregated_market_stats.log', 'w') as stats_file:
             stats_dict = {'asks': total_asks, 'bids': total_bids,
                           'fulfilled_asks': fulfilled_asks, 'fulfilled_bids': fulfilled_bids,
                           'total_quantity_traded': self.total_quantity_traded,

--- a/experiments/market/parse_market_statistics.py
+++ b/experiments/market/parse_market_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import json
 import os
 import sys

--- a/experiments/popularity/popularity_module.py
+++ b/experiments/popularity/popularity_module.py
@@ -81,7 +81,7 @@ class PopularityModule(IPv8OverlayExperimentModule):
 
     @experiment_callback
     def introduce_peers_popularity(self):
-        for peer_id in self.all_vars.iterkeys():
+        for peer_id in self.all_vars.keys():
             if int(peer_id) != self.my_id:
                 self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(peer_id))
 

--- a/experiments/tribler_idle_run/tribler_idle_run.py
+++ b/experiments/tribler_idle_run/tribler_idle_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # tribler_idle_run.py ---
 #
 # Filename: tribler_idle_run.py

--- a/experiments/trustchain/post_process_trustchain.py
+++ b/experiments/trustchain/post_process_trustchain.py
@@ -96,7 +96,7 @@ class TrustchainStatisticsParser(StatisticsParser):
                 trustchain_interactions_file.write("%d,%d\n" % (peer_a, peer_b))
 
     def aggregate_trustchain_balances(self):
-        with open('trustchain_balances.csv', 'w', 0) as balances_file:
+        with open('trustchain_balances.csv', 'w') as balances_file:
             balances_file.write('peer,total_up,total_down,balance\n')
             for peer_nr, filename, dir in self.yield_files('trustchain.txt'):
                 with open(filename) as tc_file:

--- a/experiments/trustchain/post_process_trustchain.py
+++ b/experiments/trustchain/post_process_trustchain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 import json
 import os

--- a/experiments/trustchain/trustchain_mem_db.py
+++ b/experiments/trustchain/trustchain_mem_db.py
@@ -49,7 +49,7 @@ class TrustchainMemoryDatabase(object):
 
     def get_number_of_known_blocks(self, public_key=None):
         if public_key:
-            return len([pk for pk, _ in self.block_cache.iterkeys() if pk == public_key])
+            return len([pk for pk, _ in self.block_cache.keys() if pk == public_key])
         return len(self.block_cache.keys())
 
     def contains(self, block):
@@ -83,7 +83,7 @@ class TrustchainMemoryDatabase(object):
 
     def get_lowest_range_unknown(self, public_key):
         lowest_unknown = self.get_lowest_sequence_number_unknown(public_key)
-        known_block_nums = [seq_num for pk, seq_num in self.block_cache.iterkeys() if pk == public_key]
+        known_block_nums = [seq_num for pk, seq_num in self.block_cache.keys() if pk == public_key]
         filtered_block_nums = [seq_num for seq_num in known_block_nums if seq_num > lowest_unknown]
         if filtered_block_nums:
             return lowest_unknown, filtered_block_nums[0] - 1
@@ -120,7 +120,7 @@ class TrustchainMemoryDatabase(object):
         Commit all information to the original database.
         """
         if self.original_db:
-            my_blocks = [block for block in self.block_cache.itervalues() if block.public_key == my_pub_key]
+            my_blocks = [block for block in self.block_cache.values() if block.public_key == my_pub_key]
             for block in my_blocks:
                 self.original_db.add_block(block)
 

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -186,6 +186,6 @@ class TrustchainModule(IPv8OverlayExperimentModule):
     @experiment_callback
     def write_trustchain_statistics(self):
         from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
-        with open('trustchain.txt', 'w', 0) as trustchain_file:
+        with open('trustchain.txt', 'w') as trustchain_file:
             wallet = TrustchainWallet(self.overlay)
             trustchain_file.write(json.dumps(wallet.get_statistics()))

--- a/experiments/tunnels/hidden_tunnel_module.py
+++ b/experiments/tunnels/hidden_tunnel_module.py
@@ -10,10 +10,10 @@ class HiddenTunnelModule(TunnelModule):
     def write_tunnels_info(self):
         super(HiddenTunnelModule, self).write_tunnels_info()
 
-        with open('introduction_points.txt', 'w', 0) as ips_file:
-            for infohash in self.overlay.intro_point_for.iterkeys():
+        with open('introduction_points.txt', 'w') as ips_file:
+            for infohash in self.overlay.intro_point_for.keys():
                 ips_file.write("%s,%s\n" % (self.my_id, infohash.encode('hex')))
 
-        with open('rendezvous_points.txt', 'w', 0) as rps_file:
-            for cookie in self.overlay.rendezvous_point_for.iterkeys():
+        with open('rendezvous_points.txt', 'w') as rps_file:
+            for cookie in self.overlay.rendezvous_point_for.keys():
                 rps_file.write("%s,%s\n" % (self.my_id, cookie.encode('hex')))

--- a/experiments/tunnels/parse_tunnel_statistics.py
+++ b/experiments/tunnels/parse_tunnel_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import json
 import os
 import sys

--- a/experiments/tunnels/parse_tunnel_statistics.py
+++ b/experiments/tunnels/parse_tunnel_statistics.py
@@ -18,21 +18,21 @@ class TunnelStatisticsParser(StatisticsParser):
         self.relays_info = []
 
     def aggregate_introduction_points(self):
-        with open('introduction_points.csv', 'w', 0) as ips_file:
+        with open('introduction_points.csv', 'w') as ips_file:
             ips_file.write("peer,infohash\n")
             for peer_nr, filename, dir in self.yield_files('introduction_points.txt'):
                 with open(filename) as ip_file:
                     ips_file.write(ip_file.read())
 
     def aggregate_rendezvous_points(self):
-        with open('rendezvous_points.csv', 'w', 0) as rps_file:
+        with open('rendezvous_points.csv', 'w') as rps_file:
             rps_file.write("peer,cookie\n")
             for peer_nr, filename, dir in self.yield_files('rendezvous_points.txt'):
                 with open(filename) as rp_file:
                     rps_file.write(rp_file.read())
 
     def aggregate_downloads_history(self):
-        with open('downloads_history.csv', 'w', 0) as downloads_file:
+        with open('downloads_history.csv', 'w') as downloads_file:
             downloads_file.write('peer,time,infohash,progress,status,total_up,total_down,speed_up,speed_down\n')
             for peer_nr, filename, dir in self.yield_files('downloads_history.txt'):
                 with open(filename) as individual_downloads_file:
@@ -41,7 +41,7 @@ class TunnelStatisticsParser(StatisticsParser):
                         downloads_file.write('%s,%s' % (peer_nr, line))
 
     def aggregate_circuits(self):
-        with open('circuits.csv', 'w', 0) as circuits_file:
+        with open('circuits.csv', 'w') as circuits_file:
             circuits_file.write('peer,circuit_id,state,hops,bytes_up,bytes_down,creation_time,type,first_hop\n')
             for peer_nr, filename, dir in self.yield_files('circuits.txt'):
                 with open(filename) as individual_circuits_file:
@@ -58,7 +58,7 @@ class TunnelStatisticsParser(StatisticsParser):
                         self.circuits_info.append((peer_nr, circuit_id, circuit_type, first_hop, bytes_transferred))
 
     def aggregate_relays(self):
-        with open('relays.csv', 'w', 0) as relays_file:
+        with open('relays.csv', 'w') as relays_file:
             relays_file.write('peer,circuit_id_1,circuit_id_2,destination,bytes_up\n')
             for peer_nr, filename, dir in self.yield_files('relays.txt'):
                 with open(filename) as individual_relays_file:
@@ -111,7 +111,7 @@ class TunnelStatisticsParser(StatisticsParser):
             cur_circuit_num += 1
 
         # Write circuits to file
-        with open('circuits_graph.csv', 'w', 0) as circuits_graph_file:
+        with open('circuits_graph.csv', 'w') as circuits_graph_file:
             circuits_graph_file.write('from,to,circuit_num,type,bytes_transferred\n')
             for from_peer, to_peer, circuit_num, type, bytes_transferred in edges:
                 circuits_graph_file.write('%s,%s,%s,%s,%d\n' % (from_peer, to_peer, circuit_num, type, bytes_transferred))

--- a/experiments/tunnels/tunnel_module.py
+++ b/experiments/tunnels/tunnel_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # bartercast_client.py ---
 #
 # Filename: tunnel_module.py

--- a/experiments/tunnels/tunnel_module.py
+++ b/experiments/tunnels/tunnel_module.py
@@ -95,8 +95,8 @@ class TunnelModule(IPv8OverlayExperimentModule):
                             self._logger.debug("Received peers %s (%s, %s) down total: %s, upload: %s, version %s ",
                                                peer["id"], peer["ip"], peer["port"], peer["dtotal"],
                                                peer["utotal"], peer["extended_version"])
-                    for pid, hashes in peer_aggregate.iteritems():
-                        for infohash, balance in hashes.iteritems():
+                    for pid, hashes in peer_aggregate.items():
+                        for infohash, balance in hashes.items():
                             self.session.lm.payout_manager.update_peer(pid, infohash, balance)
 
                 status_dict = {
@@ -160,19 +160,19 @@ class TunnelModule(IPv8OverlayExperimentModule):
         """
         Write information about established tunnels/introduction points/rendezvous points to files.
         """
-        with open('circuits.txt', 'w', 0) as circuits_file:
-            for circuit_id, circuit in self.overlay.circuits.iteritems():
+        with open('circuits.txt', 'w') as circuits_file:
+            for circuit_id, circuit in self.overlay.circuits.items():
                 circuits_file.write('%s,%s,%s,%s,%s,%s,%s,%s:%d\n' % (circuit_id, str(circuit.state), circuit.goal_hops,
                                                                       circuit.bytes_up, circuit.bytes_down,
                                                                       circuit.creation_time, circuit.ctype,
                                                                       circuit.peer.address[0], circuit.peer.address[1]))
 
-        with open('relays.txt', 'w', 0) as relays_file:
-            for circuit_id_1, relay in self.overlay.relay_from_to.iteritems():
+        with open('relays.txt', 'w') as relays_file:
+            for circuit_id_1, relay in self.overlay.relay_from_to.items():
                 relays_file.write('%s,%s,%s:%d,%s\n' % (circuit_id_1, relay.circuit_id, relay.peer.address[0],
                                                         relay.peer.address[1], relay.bytes_up))
 
-        with open('downloads_history.txt', 'w', 0) as downloads_file:
+        with open('downloads_history.txt', 'w') as downloads_file:
             for state_dict in self.download_states_history:
                 downloads_file.write('%f,%s,%f,%s,%f,%f,%f,%f\n' % (state_dict['time'], state_dict['infohash'],
                                                                     state_dict['progress'], state_dict['status'],

--- a/gumby/config.py
+++ b/gumby/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # config.py ---
 #
 # Filename: config.py

--- a/gumby/config.py
+++ b/gumby/config.py
@@ -64,7 +64,7 @@ class _ConfigClientProtocol(LineReceiver):
         self.config = None
 
     def connectionMade(self):
-        self.sendLine("TIME " + str(time()))
+        self.sendLine(b"TIME " + str(time()))
 
         # goto recv MYCONFIG
         self.state = 1

--- a/gumby/launch_scenario.py
+++ b/gumby/launch_scenario.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/gumby/launch_scenario_py3.py
+++ b/gumby/launch_scenario_py3.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+
+from gumby.launch_scenario import main
+
+if __name__ == '__main__':
+    main()

--- a/gumby/modules/anydex_module.py
+++ b/gumby/modules/anydex_module.py
@@ -57,10 +57,10 @@ class AnyDexModule(ExperimentModule):
         # Cleanup this dictionary
         time_elapsed = time.time() - self.experiment.scenario_runner.exp_start_time
         new_dict = {"time": time_elapsed, "stats": {}}
-        for overlay_prefix, messages_dict in statistics.iteritems():
+        for overlay_prefix, messages_dict in statistics.items():
             hex_prefix = overlay_prefix.encode('hex')
             new_dict["stats"][hex_prefix] = {}
-            for msg_id, msg_stats in messages_dict.iteritems():
+            for msg_id, msg_stats in messages_dict.items():
                 new_dict["stats"][hex_prefix][msg_id] = msg_stats.to_dict()
 
         with open('ipv8_statistics.txt', 'a') as statistics_file:

--- a/gumby/modules/base_ipv8_module.py
+++ b/gumby/modules/base_ipv8_module.py
@@ -34,10 +34,10 @@ class BaseIPv8Module(ExperimentModule):
         # Cleanup this dictionary
         time_elapsed = time.time() - self.experiment.scenario_runner.exp_start_time
         new_dict = {"time": time_elapsed, "stats": {}}
-        for overlay_prefix, messages_dict in statistics.iteritems():
+        for overlay_prefix, messages_dict in statistics.items():
             hex_prefix = overlay_prefix.encode('hex')
             new_dict["stats"][hex_prefix] = {}
-            for msg_id, msg_stats in messages_dict.iteritems():
+            for msg_id, msg_stats in messages_dict.items():
                 new_dict["stats"][hex_prefix][msg_id] = msg_stats.to_dict()
 
         with open('ipv8_statistics.txt', 'a') as statistics_file:

--- a/gumby/modules/community_experiment_module.py
+++ b/gumby/modules/community_experiment_module.py
@@ -1,3 +1,4 @@
+from base64 import b64encode, b64decode
 from random import sample
 
 from gumby.experiment import experiment_callback
@@ -109,7 +110,7 @@ class IPv8OverlayExperimentModule(ExperimentModule):
 
         if not max_peers:
             # bootstrap the peer introduction, ensuring everybody knows everybody to start off with.
-            for peer_id in self.all_vars.iterkeys():
+            for peer_id in self.all_vars.keys():
                 if int(peer_id) != self.my_id and int(peer_id) not in excluded_peers_list:
                     self.overlay.walk_to(self.experiment.get_peer_ip_port_by_id(peer_id))
         else:
@@ -133,10 +134,10 @@ class IPv8OverlayExperimentModule(ExperimentModule):
     def get_peer(self, peer_id):
         target = self.all_vars[peer_id]
         address = (str(target['host']), target['port'])
-        return Peer(self.get_peer_public_key(peer_id).decode("base64"), address=address)
+        return Peer(b64decode(self.get_peer_public_key(peer_id)), address=address)
 
     def get_peer_public_key(self, peer_id):
-        return self.all_vars[peer_id]['public_key']
+        return self.all_vars[peer_id][b'public_key']
 
     def on_id_received(self):
         # Since the IPv8 source module is loaded before any community module, the IPv8 on_id_received has
@@ -151,7 +152,7 @@ class IPv8OverlayExperimentModule(ExperimentModule):
         save_keypair_trustchain(keypair, pairfilename)
         save_pub_key_trustchain(keypair, "%s.pub" % pairfilename)
 
-        self.vars['public_key'] = str(keypair.pub().key_to_bin()).encode("base64")
+        self.vars['public_key'] = b64encode(keypair.pub().key_to_bin()).decode('utf-8')
 
     def on_ipv8_available(self, ipv8):
         # The IPv8 object is now available. This means that the tribler_config has been copy constructed into the

--- a/gumby/modules/dht_module.py
+++ b/gumby/modules/dht_module.py
@@ -51,26 +51,26 @@ class DHTModule(ExperimentModule):
 
     def on_all_vars_received(self):
         super(DHTModule, self).on_id_received()
-        for node_dict in self.all_vars.itervalues():
+        for node_dict in self.all_vars.values():
             if "dht_node_port" in node_dict:
                 self.dht_nodes.append((str(node_dict["host"]), int(node_dict["dht_node_port"])))
 
     @experiment_callback
     def print_dht_table(self):
-        for ltsession in self.lm.ltmgr.ltsessions.itervalues():
+        for ltsession in self.lm.ltmgr.ltsessions.values():
             if hasattr(ltsession, 'post_dht_stats'):
                 ltsession.post_dht_stats()
 
     @experiment_callback
     def disable_libtorrent_dht(self):
-        for sess in self.lm.ltmgr.ltsessions.itervalues():
+        for sess in self.lm.ltmgr.ltsessions.values():
             settings = sess.get_settings()
             settings["enable_dht"] = False
             sess.set_settings(settings)
 
     @experiment_callback
     def enable_libtorrent_dht(self):
-        for sess in self.lm.ltmgr.ltsessions.itervalues():
+        for sess in self.lm.ltmgr.ltsessions.values():
             settings = sess.get_settings()
             settings["enable_dht"] = True
             sess.set_settings(settings)

--- a/gumby/modules/isolated_community_loader.py
+++ b/gumby/modules/isolated_community_loader.py
@@ -50,8 +50,9 @@ class IsolatedIPv8LauncherWrapper(IPv8CommunityLauncher):
         from ipv8.keyvault.crypto import ECCrypto
         eccrypto = ECCrypto()
         unique_id = self.get_name() + self.session_id
-        private_bin = "".join([unique_id[i] if i < len(unique_id) else "0" for i in range(68)])
-        eckey = eccrypto.key_from_private_bin("LibNaCLSK:" + private_bin)
+        unique_id = unique_id.encode('utf-8')
+        private_bin = b"".join([unique_id[i:i+1] if i < len(unique_id) else b"0" for i in range(68)])
+        eckey = eccrypto.key_from_private_bin(b"LibNaCLSK:" + private_bin)
         master_peer = Peer(eckey.pub().key_to_bin())
         overlay.master_peer = master_peer
 

--- a/gumby/modules/tribler_module.py
+++ b/gumby/modules/tribler_module.py
@@ -75,7 +75,7 @@ class TriblerModule(BaseIPv8Module):
     def set_libtorrentmgr_alert_mask(self, mask=0xffffffff):
         self.session.lm.ltmgr.default_alert_mask = mask
         self.session.lm.ltmgr.alert_callback = self._process_libtorrent_alert
-        for ltsession in self.session.lm.ltmgr.ltsessions.itervalues():
+        for ltsession in self.session.lm.ltmgr.ltsessions.values():
             ltsession.set_alert_mask(mask)
 
     @experiment_callback
@@ -253,7 +253,7 @@ class TriblerModule(BaseIPv8Module):
         """
         Write information about the IPv8 overlay networks to a file.
         """
-        with open('overlays.txt', 'w', 0) as overlays_file:
+        with open('overlays.txt', 'w') as overlays_file:
             overlays_file.write("name,pub_key,peers\n")
             for overlay in self.session.lm.ipv8.overlays:
                 overlays_file.write("%s,%s,%d\n" % (overlay.__class__.__name__,
@@ -261,12 +261,12 @@ class TriblerModule(BaseIPv8Module):
                                                     len(overlay.get_peers())))
 
         # Write verified peers
-        with open('verified_peers.txt', 'w', 0) as peers_file:
+        with open('verified_peers.txt', 'w') as peers_file:
             for peer in self.session.lm.ipv8.network.verified_peers:
                 peers_file.write('%d\n' % (peer.address[1] - 12000))
 
         # Write bandwidth statistics
-        with open('bandwidth.txt', 'w', 0) as bandwidth_file:
+        with open('bandwidth.txt', 'w') as bandwidth_file:
             bandwidth_file.write("%d,%d" % (self.session.lm.ipv8.endpoint.bytes_up,
                                             self.session.lm.ipv8.endpoint.bytes_down))
 
@@ -275,7 +275,7 @@ class TriblerModule(BaseIPv8Module):
         """
         Write away information about the downloads in Tribler.
         """
-        with open('downloads.txt', 'w', 0) as downloads_file:
+        with open('downloads.txt', 'w') as downloads_file:
             downloads_file.write('infohash,status,progress\n')
             for download in self.session.get_downloads():
                 state = download.get_state()

--- a/gumby/runner.py
+++ b/gumby/runner.py
@@ -375,8 +375,8 @@ class OneShotProcessProtocol(ProcessProtocol):
         self._logger = logging.getLogger(self.__class__.__name__)
 
         self.command = command
-        self._stdout_bytes = ''
-        self._stderr_bytes = ''
+        self._stdout_bytes = b''
+        self._stderr_bytes = b''
         self._d = Deferred()
 
     def processExited(self, reason):
@@ -391,11 +391,11 @@ class OneShotProcessProtocol(ProcessProtocol):
     def outReceived(self, data):
         # we could recv more than 1 line and/or a partial line.
         self._stdout_bytes += data
-        remainder = ""
+        remainder = b""
         for line in self._stdout_bytes.splitlines(True):
-            if line.endswith('\n'):
-                self._logger.info('[%s] OUT: %s', self.command[:20].strip() + "..." if len(self.command) >20 else "",
-                                  line.rstrip())
+            if line.endswith(b'\n'):
+                self._logger.info('[%s] OUT: %s', self.command[:20].strip() + "..." if len(self.command) > 20 else "",
+                                  line.rstrip().decode('utf-8'))
             else:
                 # It's a partial line (part of the last one), save it to the buffer instead
                 remainder = line
@@ -403,11 +403,11 @@ class OneShotProcessProtocol(ProcessProtocol):
 
     def errReceived(self, data):
         self._stderr_bytes += data
-        remainder = ""
+        remainder = b""
         for line in self._stderr_bytes.splitlines(True):
-            if line.endswith('\n'):
-                self._logger.info('[%s] ERR: %s', self.command[:20].strip() + "..." if len(self.command) >20 else "",
-                                  line.rstrip())
+            if line.endswith(b'\n'):
+                self._logger.info('[%s] ERR: %s', self.command[:20].strip() + "..." if len(self.command) > 20 else "",
+                                  line.rstrip().decode('utf-8'))
             else:
                 # It's a partial line (part of the last one), save it to the buffer instead
                 remainder = line

--- a/gumby/runner.py
+++ b/gumby/runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # run.py ---
 #
 # Filename: run.py

--- a/gumby/scenario.py
+++ b/gumby/scenario.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # scenario.py ---
 #
 # Filename: scenario.py

--- a/gumby/settings.py
+++ b/gumby/settings.py
@@ -79,20 +79,20 @@ def loadConfig(file_path):
     # TODO: Find a better way to do this (If the default value for a list is an empty list, it just doesn't set the value at all)
     if 'head_nodes' not in config:
         config["head_nodes"] = []
-    for key, value in config.iteritems():
+    for key, value in config.items():
         # If any config option has the special value __unique_port__, compute a unique port for it by hashing the user
         # ID, the experiment name, the experiment execution dir and the config option name.
         if value == '__unique_port__':
             md5sum = md5()
-            md5sum.update(getuser())
-            md5sum.update(config['experiment_name'])
-            md5sum.update(path.abspath(curdir))
-            md5sum.update(key)
+            md5sum.update(getuser().encode('utf-8'))
+            md5sum.update(config['experiment_name'].encode('utf-8'))
+            md5sum.update(path.abspath(curdir).encode('utf-8'))
+            md5sum.update(key.encode('utf-8'))
             config[key] = int(md5sum.hexdigest()[-16:], 16) % 20000 + 20000
 
     # Override config options with env. variables.
     revalidate = False
-    for key, value in environ.iteritems():
+    for key, value in environ.items():
         if key.startswith("GUMBY_"):
             name = key[6:].lower()  # "GUMBY_".len()
             config[name] = value
@@ -107,7 +107,7 @@ def configToEnv(config):
     Processes a dictionary of config options so it can be exported as env. variables when running a subprocess.
     """
     env = {}
-    for name, val in config.iteritems():
+    for name, val in config.items():
         env[name.upper()] = path.expanduser(path.expandvars(str(val)))
     return env
 #

--- a/gumby/sync.py
+++ b/gumby/sync.py
@@ -106,7 +106,7 @@ class ExperimentServiceProto(LineReceiver):
 
     def sendAndWaitForReady(self):
         self.ready_d = Deferred()
-        self.sendLine("id:%s" % self.id)
+        self.sendLine(b"id:%s" % self.id)
         return self.ready_d
 
     def connectionLost(self, reason=connectionDone):
@@ -238,11 +238,11 @@ class ExperimentServiceFactory(Factory):
             vars[subscriber.id] = subscriber_vars
 
         vars = {
-            "server":
+            b"server":
                 {
-                    "global_random": randint(0, (2 ** 32) - 1)
+                    b"global_random": randint(0, (2 ** 32) - 1)
                 },
-            "clients": vars
+            b"clients": vars
         }
         json_vars = json.dumps(vars)
         del vars
@@ -283,7 +283,7 @@ class ExperimentServiceFactory(Factory):
         start_time = time() + self.experiment_start_delay
         for subscriber in self.connections_ready:
             # Sync the experiment start time among instances
-            subscriber.sendLine("go:%f" % (start_time + subscriber.vars['time_offset']))
+            subscriber.sendLine(b"go:%f" % (start_time + subscriber.vars['time_offset']))
 
         d = deferLater(reactor, 5, lambda: self._logger.info("Done, disconnecting all clients."))
         d.addCallback(lambda _: self.disconnectAll())

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # run.py ---
 #
 # Filename: run.py

--- a/scripts/collect_profile_logs.py
+++ b/scripts/collect_profile_logs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import os
 import shutil
 import sys

--- a/scripts/experiment_server.py
+++ b/scripts/experiment_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # experiment_server.py ---
 #
 # Filename: experiment_server.py

--- a/scripts/extract_process_guard_stats.py
+++ b/scripts/extract_process_guard_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 import sys
 import os

--- a/scripts/extract_process_guard_stats.py
+++ b/scripts/extract_process_guard_stats.py
@@ -25,7 +25,7 @@ def write_records(all_nodes, sum_records, output_directory, outputfile, diffoutp
             print('time', ' '.join(all_nodes), file=fp2)
 
         prev_records = {}
-        for time in sorted(sum_records.iterkeys()):
+        for time in sorted(sum_records.keys()):
             print(time, end=' ', file=fp)
             if fp2:
                 print(time, end=' ', file=fp2)
@@ -160,15 +160,15 @@ def parse_resource_files(input_directory, output_directory, start_timestamp=None
     # some sanity checks
     nr_1utime = defaultdict(int)
     warn_utime = {}
-    for pid_dict in utimes.itervalues():
-        for pid, utime in pid_dict.iteritems():
+    for pid_dict in utimes.values():
+        for pid, utime in pid_dict.items():
             if isinstance(utime, float) and utime > 0.9:
                 nr_1utime[pid] += 1
 
             if nr_1utime[pid] > 5:
                 warn_utime[pid] = max(nr_1utime[pid], warn_utime.get(pid, nr_1utime[pid]))
 
-    for pid, times in warn_utime.iteritems():
+    for pid, times in warn_utime.items():
         print("A process with name (%s) was measured to have a utime larger than 0.9 for %d times"
               % (pid, times), file=sys.stderr)
 
@@ -185,7 +185,7 @@ def parse_resource_files(input_directory, output_directory, start_timestamp=None
 
     # calculate sum for all nodes
     for dictionary in [utimes, stimes, wchars, rchars, vsizes, rsizes, writebytes, readbytes]:
-        for time, values in dictionary.iteritems():
+        for time, values in dictionary.items():
             for node in all_nodes:
                 if node in values:
                     values[node] = sum(values[node])

--- a/scripts/generate_config_file.py
+++ b/scripts/generate_config_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # create_conf.py ---
 #
 # Filename: create_conf.py

--- a/scripts/generate_config_file.py
+++ b/scripts/generate_config_file.py
@@ -181,7 +181,7 @@ if __name__ == '__main__':
                             config_file.write('#\n')
                         if config_opts:
                             config_file.write('# Config options:\n#\n' )
-                            for config_opt in config_opts.iteritems():
+                            for config_opt in config_opts.items():
                                 config_file.write('# %s\n# %s = \n#\n' % tuple(reversed(config_opt)))
 
 #

--- a/scripts/modify_annotations.py
+++ b/scripts/modify_annotations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 import sys
 import os

--- a/scripts/modify_autoplot.py
+++ b/scripts/modify_autoplot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 import sys
 import os

--- a/scripts/post_process_historical_values.py
+++ b/scripts/post_process_historical_values.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 import csv

--- a/scripts/process_guard.py
+++ b/scripts/process_guard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Mircea Bardac
 # Rewritten by Elric Milon (Dec. 2012 and Aug. 2013)
 

--- a/scripts/process_guard.py
+++ b/scripts/process_guard.py
@@ -73,7 +73,7 @@ class ResourceMonitor(object):
             else:
                 return True
         pids_to_remove = set()
-        for pid, popen in self.pid_dict.iteritems():
+        for pid, popen in self.pid_dict.items():
             if popen.poll() is not None:
                 pids_to_remove.add(pid)
 
@@ -274,7 +274,7 @@ class ProcessMonitor(object):
         self._rm.terminate()
         if failed:
             print("Some processes failed:")
-            for pid, (command, exit_code) in failed.iteritems():
+            for pid, (command, exit_code) in failed.items():
                 print("  %s (%d) exited value: %d" % (command, pid, exit_code))
             print("Process guard exiting with error")
             return COMMANDS_FAILED_EXIT_CODE

--- a/scripts/pycompile.py
+++ b/scripts/pycompile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # pycompile.py ---
 #
 # Filename: pycompile.py

--- a/scripts/reduce_statistics.py
+++ b/scripts/reduce_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 import sys
 import os

--- a/scripts/reduce_statistics.py
+++ b/scripts/reduce_statistics.py
@@ -46,7 +46,7 @@ def reduce(base_directory, nrlines, inputfile, outputfile, removeinputfile=True)
                 if (i + 1) % nrlines_to_merge == 0 or (i + 1 == len(lines)):
                     print(max_time, end=' ', file=ofp)
 
-                    for j, parts in to_be_merged_parts.iteritems():
+                    for j, parts in to_be_merged_parts.items():
                         mean = float_or_unknown_mean(parts)
                         print(mean, end=' ', file=ofp)
 

--- a/scripts/run_in_env.py
+++ b/scripts/run_in_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # run_in_env.py ---
 #
 # Filename: run_in_env.py


### PR DESCRIPTION
In this PR, I made Gumby partially Python 3 compatible, at least for my own experiment (see [here](https://jenkins-ci.tribler.org/job/AnyDex/job/validation_experiment_market/)).

We still have to fix libtorrent since it does not load properly under Python 3 for some reason. Additionally, the post-experiment scripts are still executed with Python 2, due to the shebangs used there. Also, since Tribler is not fully Python 3 compatible yet, support for Python 3 is fully optional and "old" experiments written with Python 2 should still work.

To run new experiments under Python 3, make sure to pass the `--py3` flag to the `build_virtualenv.sh` script (so it will prepare a Python 3 virtualenv for you), and that you call `run.py` with Python 3 (for example: `python3 gumby/run.py gumby/experiments/market/market_experiment.conf`). These changes should be enough to run your experiment under Python 3. 🎉 

[Validation experiment to build a Python 3 venv from scratch](https://jenkins-ci.tribler.org/job/test_build_environment_das5_py3).
[Example of a Gumby experiment executed with Python 3](https://jenkins-ci.tribler.org/job/AnyDex/job/validation_experiment_market/450/).
[Confirmed to still work under Python 2.](https://jenkins-ci.tribler.org/job/validation_experiments/job/validation_experiment_popularity/92/)