### PR TITLE
Made Gumby Python 3 compatible

### DIFF
--- a/experiments/dht/dht_module.py
+++ b/experiments/dht/dht_module.py
@@ -1,4 +1,5 @@
 import time
+from binascii import unhexlify
 
 from gumby.experiment import experiment_callback
 from gumby.modules.community_experiment_module import IPv8OverlayExperimentModule
@@ -35,11 +36,11 @@ class DHTModule(IPv8OverlayExperimentModule):
 
     @experiment_callback
     def store(self, key, value):
-        self.log_timing(self.overlay.store_value(key.decode('hex'), value), 'store')
+        self.log_timing(self.overlay.store_value(unhexlify(key), value), 'store')
 
     @experiment_callback
     def find(self, key):
-        self.log_timing(self.overlay.find_values(key.decode('hex')), 'find')
+        self.log_timing(self.overlay.find_values(unhexlify(key)), 'find')
 
     @experiment_callback
     def do_dht_announce(self):

--- a/experiments/dht/dht_module.py
+++ b/experiments/dht/dht_module.py
@@ -36,7 +36,7 @@ class DHTModule(IPv8OverlayExperimentModule):
 
     @experiment_callback
     def store(self, key, value):
-        self.log_timing(self.overlay.store_value(unhexlify(key), value), 'store')
+        self.log_timing(self.overlay.store_value(unhexlify(key), value.encode('utf-8')), 'store')
 
     @experiment_callback
     def find(self, key):

--- a/experiments/gigachannel/gigachannel_module.py
+++ b/experiments/gigachannel/gigachannel_module.py
@@ -47,8 +47,7 @@ class GigaChannelModule(IPv8OverlayExperimentModule):
         with db_session:
             self.autoplot_add_point('known_channels', len(list(self.session.lm.mds.ChannelMetadata.select())))
             self.autoplot_add_point('total_torrents', len(list(self.session.lm.mds.TorrentMetadata.select())))
-        self.autoplot_add_point('downloading_channels',
-                                len([c for c in self.session.lm.get_downloads() if c.get_channel_download()]))
+        self.autoplot_add_point('downloading_channels', len(self.session.lm.get_downloads()))
         self.autoplot_add_point('completed_channels',
-                                len([c for c in self.session.lm.get_downloads() if c.get_channel_download() and
-                                     c.get_state().get_status() == DLSTATUS_SEEDING]))
+                                len([c for c in self.session.lm.get_downloads()
+                                     if c.get_state().get_status() == DLSTATUS_SEEDING]))

--- a/experiments/trustchain/post_process_trustchain.py
+++ b/experiments/trustchain/post_process_trustchain.py
@@ -105,13 +105,9 @@ class TrustchainStatisticsParser(StatisticsParser):
             for peer_nr, filename, dir in self.yield_files('trustchain.txt'):
                 with open(filename) as tc_file:
                     tc_json = json.loads(tc_file.read())
-                    total_up = 0
-                    total_down = 0
-                    balance = 0
-                    if 'latest_block' in tc_json and tc_json['latest_block']['type'] == 'tribler_bandwidth':
-                        total_up = tc_json['latest_block']['transaction']['total_up']
-                        total_down = tc_json['latest_block']['transaction']['total_down']
-                        balance = total_up - total_down
+                    total_up = tc_json['total_up']
+                    total_down = tc_json['total_down']
+                    balance = total_up - total_down
                     balances_file.write('%s,%d,%d,%d\n' % (peer_nr, total_up, total_down, balance))
 
     def run(self):

--- a/experiments/trustchain/post_process_trustchain.py
+++ b/experiments/trustchain/post_process_trustchain.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 from __future__ import print_function
+
 import json
 import os
 import sys
 
 from gumby.statsparser import StatisticsParser
+
+from Tribler.Core.Utilities.unicode import hexlify
+
 from scripts.trustchain_database_reader import GumbyDatabaseAggregator
 
 
@@ -60,27 +64,27 @@ class TrustchainStatisticsParser(StatisticsParser):
 
             # Write blocks
             for block in blocks:
-                if block.link_public_key.encode('hex') not in key_map:
+                if hexlify(block.link_public_key) not in key_map:
                     link_peer = 0
                 else:
-                    link_peer = key_map[block.link_public_key.encode('hex')]
+                    link_peer = key_map[hexlify(block.link_public_key)]
 
-                if block.public_key.encode('hex') not in key_map:
-                    print("Public key %s cannot be mapped to a peer!" % block.public_key.encode('hex'))
+                if hexlify(block.public_key) not in key_map:
+                    print("Public key %s cannot be mapped to a peer!" % hexlify(block.public_key))
                     continue
 
-                peer = key_map[block.public_key.encode('hex')]
+                peer = key_map[hexlify(block.public_key)]
                 trustchain_file.write(
                     "%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%d;%s;%s\n" % (
                         peer,
-                        block.public_key.encode('hex'),
+                        hexlify(block.public_key),
                         block.sequence_number,
                         link_peer,
-                        block.link_public_key.encode('hex'),
+                        hexlify(block.link_public_key),
                         block.link_sequence_number,
-                        block.previous_hash.encode('hex'),
-                        block.signature.encode('hex'),
-                        block.hash.encode('hex'),
+                        hexlify(block.previous_hash),
+                        hexlify(block.signature),
+                        hexlify(block.hash),
                         block.type,
                         block.timestamp,
                         block.timestamp - start_time,

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -77,11 +77,11 @@ class TrustchainModule(IPv8OverlayExperimentModule):
         with open(self.block_stat_file, "w") as t_file:
             writer = csv.DictWriter(t_file, ['time', 'transaction'])
             writer.writeheader()
-        self.overlay.add_listener(GeneratedBlockListener(self.block_stat_file), ['test'])
+        self.overlay.add_listener(GeneratedBlockListener(self.block_stat_file), [b'test'])
 
     @experiment_callback
     def init_trustchain(self):
-        self.overlay.add_listener(FakeBlockListener(), ['test'])
+        self.overlay.add_listener(FakeBlockListener(), [b'test'])
 
     @experiment_callback
     def disable_max_peers(self):

--- a/experiments/trustchain/trustchain_module.py
+++ b/experiments/trustchain/trustchain_module.py
@@ -167,7 +167,7 @@ class TrustchainModule(IPv8OverlayExperimentModule):
         peer_id = self.experiment.get_peer_id(peer.address[0], peer.address[1])
         self._logger.info("%s: Requesting signature from peer: %s", self.my_id, peer_id)
         transaction = {"up": up, "down": down, "from_peer": self.my_id, "to_peer": peer_id}
-        self.overlay.sign_block(peer, peer.public_key.key_to_bin(), block_type='test', transaction=transaction)
+        self.overlay.sign_block(peer, peer.public_key.key_to_bin(), block_type=b'test', transaction=transaction)
 
     def check_num_blocks_in_db(self):
         """

--- a/experiments/tunnels/hidden_tunnel_module.py
+++ b/experiments/tunnels/hidden_tunnel_module.py
@@ -2,6 +2,8 @@ from experiments.tunnels.tunnel_module import TunnelModule
 from gumby.experiment import experiment_callback
 from gumby.modules.experiment_module import static_module
 
+from Tribler.Core.Utilities.unicode import hexlify
+
 
 @static_module
 class HiddenTunnelModule(TunnelModule):
@@ -12,8 +14,8 @@ class HiddenTunnelModule(TunnelModule):
 
         with open('introduction_points.txt', 'w') as ips_file:
             for infohash in self.overlay.intro_point_for.keys():
-                ips_file.write("%s,%s\n" % (self.my_id, infohash.encode('hex')))
+                ips_file.write("%s,%s\n" % (self.my_id, hexlify(infohash)))
 
         with open('rendezvous_points.txt', 'w') as rps_file:
             for cookie in self.overlay.rendezvous_point_for.keys():
-                rps_file.write("%s,%s\n" % (self.my_id, cookie.encode('hex')))
+                rps_file.write("%s,%s\n" % (self.my_id, hexlify(cookie)))

--- a/experiments/tunnels/tunnel_module.py
+++ b/experiments/tunnels/tunnel_module.py
@@ -39,8 +39,10 @@
 import time
 from binascii import unhexlify
 
+from Tribler.Core.Utilities.unicode import hexlify
 from Tribler.Core.simpledefs import dlstatus_strings, DOWNLOAD, UPLOAD
 from Tribler.community.triblertunnel.community import TriblerTunnelCommunity
+
 from ipv8.messaging.anonymization.community import TunnelSettings
 
 from gumby.experiment import experiment_callback
@@ -101,7 +103,7 @@ class TunnelModule(IPv8OverlayExperimentModule):
 
                 status_dict = {
                     "time": time.time() - self.experiment.scenario_runner.exp_start_time,
-                    "infohash": download.get_def().get_infohash().encode('hex'),
+                    "infohash": hexlify(download.get_def().get_infohash()),
                     "progress": state.get_progress(),
                     "status": dlstatus_strings[state.get_status()],
                     "total_up": state.get_total_transferred(UPLOAD),

--- a/gumby/experiment.py
+++ b/gumby/experiment.py
@@ -296,6 +296,7 @@ class ExperimentClient(LineReceiver):
         """
         if module_name in sys.modules and sys.modules[module_name]:
             return sys.modules[module_name]
+        import_exception = None
         try:
             # Can raise ImportError when module_name cannot be imported
             __import__(module_name, level=0)
@@ -303,12 +304,12 @@ class ExperimentClient(LineReceiver):
             if sys.modules[module_name]:
                 # The module can still be unloaded
                 return sys.modules[module_name]
-        except AttributeError:
-            pass # Fall into the error message
-        except ImportError:
-            pass # Fall into the error message
+        except AttributeError as exc:
+            import_exception = exc
+        except ImportError as exc:
+            import_exception = exc
         if logger:
-            logger.info("Unable to load %s as a local module", module_name)
+            logger.info("Unable to load %s as a local module, exception: %s", module_name, import_exception)
         return None
 
     @staticmethod

--- a/gumby/instrumentation.py
+++ b/gumby/instrumentation.py
@@ -88,7 +88,11 @@ def start_memory_dumper():
     Initiates the memory profiler.
     """
     logger.info("starting memory dump looping call")
-    from meliae import scanner
+    try:
+        from meliae import scanner
+    except ImportError:
+        logger.error("Meliae is not available on Python 3!")
+
     # Setup the whole thing
     start = time()
     memdump_dir = path.join(environ["OUTPUT_DIR"], "memprof", str(PID))

--- a/gumby/modules/anydex_module.py
+++ b/gumby/modules/anydex_module.py
@@ -1,7 +1,8 @@
 import json
-from os import environ, makedirs, symlink, path, getpid
-
 import time
+from binascii import hexlify
+from os import environ, getpid, makedirs, symlink, path
+
 from twisted.internet.defer import Deferred
 from twisted.internet.task import LoopingCall
 
@@ -58,7 +59,7 @@ class AnyDexModule(ExperimentModule):
         time_elapsed = time.time() - self.experiment.scenario_runner.exp_start_time
         new_dict = {"time": time_elapsed, "stats": {}}
         for overlay_prefix, messages_dict in statistics.items():
-            hex_prefix = overlay_prefix.encode('hex')
+            hex_prefix = hexlify(overlay_prefix).decode('utf-8')
             new_dict["stats"][hex_prefix] = {}
             for msg_id, msg_stats in messages_dict.items():
                 new_dict["stats"][hex_prefix][msg_id] = msg_stats.to_dict()

--- a/gumby/modules/base_ipv8_module.py
+++ b/gumby/modules/base_ipv8_module.py
@@ -1,4 +1,5 @@
 import json
+from binascii import hexlify
 from os import environ, makedirs, symlink, path, getpid
 from socket import gethostbyname
 
@@ -36,7 +37,7 @@ class BaseIPv8Module(ExperimentModule):
         time_elapsed = time.time() - self.experiment.scenario_runner.exp_start_time
         new_dict = {"time": time_elapsed, "stats": {}}
         for overlay_prefix, messages_dict in statistics.items():
-            hex_prefix = overlay_prefix.encode('hex')
+            hex_prefix = hexlify(overlay_prefix).decode('utf-8')
             new_dict["stats"][hex_prefix] = {}
             for msg_id, msg_stats in messages_dict.items():
                 new_dict["stats"][hex_prefix][msg_id] = msg_stats.to_dict()

--- a/gumby/modules/community_experiment_module.py
+++ b/gumby/modules/community_experiment_module.py
@@ -131,7 +131,7 @@ class IPv8OverlayExperimentModule(ExperimentModule):
 
         strategy = self.strategies[name]
 
-        self.session.lm.ipv8.strategies.append((strategy(self.overlay, **kwargs), max_peers))
+        self.session.lm.ipv8.strategies.append((strategy(self.overlay, **kwargs), int(max_peers)))
 
     def get_peer(self, peer_id):
         target = self.all_vars[peer_id]

--- a/gumby/modules/tribler_module.py
+++ b/gumby/modules/tribler_module.py
@@ -2,7 +2,6 @@ import glob
 import os
 import random
 
-from posix import environ
 from random import Random
 
 import binascii
@@ -126,7 +125,7 @@ class TriblerModule(BaseIPv8Module):
         """
         assert action in ("download", "seed"), "Invalid transfer kind"
 
-        file_name = os.path.basename(environ["SCENARIO_FILE"])
+        file_name = os.path.basename(os.environ["SCENARIO_FILE"])
         if download_id:
             download_id = int(download_id)
         else:
@@ -149,7 +148,7 @@ class TriblerModule(BaseIPv8Module):
         dscfg = DownloadConfig(state_dir=self.session.config.get_state_dir())
         if hops is not None:
             dscfg.set_hops(hops)
-        dscfg.set_dest_dir(os.path.join(environ["OUTPUT_DIR"], str(self.my_id)))
+        dscfg.set_dest_dir(os.path.join(os.environ["OUTPUT_DIR"], str(self.my_id)))
         if action == "download":
             os.remove(os.path.join(dscfg.get_dest_dir(), file_name))
 
@@ -228,7 +227,7 @@ class TriblerModule(BaseIPv8Module):
 
     @experiment_callback
     def remove_download_data(self):
-        for f in glob.glob(environ["SCENARIO_FILE"] + "*"):
+        for f in glob.glob(os.environ["SCENARIO_FILE"] + "*"):
             os.remove(f)
 
     @staticmethod

--- a/gumby/modules/tribler_module.py
+++ b/gumby/modules/tribler_module.py
@@ -190,7 +190,7 @@ class TriblerModule(BaseIPv8Module):
         if action == 'download':
             # Schedule a DHT lookup to fetch peers to add to this download
             def on_peers(info):
-                _, peers, _ = info
+                _, peers = info
                 self._logger.debug("Received peers for seeder lookup: %s", str(peers))
                 for peer in peers:
                     download.add_peer(peer)

--- a/gumby/modules/tribler_module.py
+++ b/gumby/modules/tribler_module.py
@@ -18,6 +18,7 @@ from gumby.modules.base_ipv8_module import BaseIPv8Module
 from ipv8.dht.provider import DHTCommunityProvider
 
 from Tribler.Core.Config.download_config import DownloadConfig
+from Tribler.Core.Utilities.unicode import hexlify
 from Tribler.Core.simpledefs import dlstatus_strings
 from Tribler.Core.TorrentDef import TorrentDef
 
@@ -155,7 +156,7 @@ class TriblerModule(BaseIPv8Module):
         def cb(ds):
             self._logger.info('transfer: %s infohash=%s, hops=%d, down=%d, up=%d, progress=%s, status=%s, seeds=%s',
                               action,
-                              tdef.get_infohash().encode('hex')[:5],
+                              hexlify(tdef.get_infohash())[:5],
                               hops if hops else 0,
                               ds.get_current_speed('down'),
                               ds.get_current_speed('up'),
@@ -261,7 +262,7 @@ class TriblerModule(BaseIPv8Module):
             overlays_file.write("name,pub_key,peers\n")
             for overlay in self.session.lm.ipv8.overlays:
                 overlays_file.write("%s,%s,%d\n" % (overlay.__class__.__name__,
-                                                    overlay.my_peer.public_key.key_to_bin().encode('hex'),
+                                                    hexlify(overlay.my_peer.public_key.key_to_bin()),
                                                     len(overlay.get_peers())))
 
         # Write verified peers
@@ -284,6 +285,6 @@ class TriblerModule(BaseIPv8Module):
             for download in self.session.get_downloads():
                 state = download.get_state()
                 downloads_file.write("%s,%s,%f\n" % (
-                    download.get_def().get_infohash().encode('hex'),
+                    hexlify(download.get_def().get_infohash()),
                     dlstatus_strings[state.get_status()],
                     state.get_progress()))

--- a/gumby/scenario.py
+++ b/gumby/scenario.py
@@ -51,6 +51,8 @@ from re import compile as re_compile
 from threading import RLock
 from time import time
 
+from six.moves import xrange
+
 from twisted.internet import reactor
 
 

--- a/scripts/build_virtualenv.sh
+++ b/scripts/build_virtualenv.sh
@@ -82,7 +82,7 @@ if [ -e $VENV/.completed.$SCRIPT_VERSION ]; then
 fi
 
 # If we compile for Python 3, we want to install a newer version since the version on the DAS5 is outdated.
-if [[ $* == *--py3* ]] && [ ! -e ~/python3/bin/python ]; then
+if [[ $* == *--py3* ]] && [ ! -e ~/python3/bin/python3 ]; then
     pushd $HOME
     wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
     tar -xzvf Python-3.7.3.tgz

--- a/scripts/build_virtualenv.sh
+++ b/scripts/build_virtualenv.sh
@@ -284,6 +284,8 @@ CFLAGS="$CFLAGS -I$VENV/include" LDFLAGS="$LDFLAGS -L$VENV/lib" pip install --up
 
 echo "
 bcrypt
+chardet
+cherrypy
 configobj
 cryptography
 cython
@@ -299,6 +301,7 @@ psutil
 pyasn1 # for twisted
 pycrypto # Twisted needs it
 pynacl # New EC crypto stuff for tunnelcommunity
+pyOpenSSL
 qrcode
 service_identity
 six


### PR DESCRIPTION
In this PR, I did some work to ensure that the validation experiments are passing on Python 3. In particular, I made Python 3 versions for all validation experiments (except for the bootstrap experiment and torrent popularity gossip experiment which will follow later), see [here](https://jenkins-ci.tribler.org/job/validation_experiments/job/validation_experiments_py3/).

Specific changes:
- When setting up a Python 3 `virtualenv` environment, the `boost` and `libtorrent` libraries are manually compiled with the `boost_python37` component included. When building a Python 2 `virtualenv` environment, it will still link `libtorrent` against the system's `boost`. (see [here](https://jenkins-ci.tribler.org/job/test_build_environment_das5_py3/25/))
- Added missing dependencies in the `build_env.sh` script
- General Python 3-compatibility fixes
- Small improvements to some experiments.
- Extended error logging when a local import fails.

Note that the hidden seeding experiment, both with Python 2 and 3, is failing. This is most likely related to the recent changes in the hidden services logic.