### PR TITLE
Decoding variables in sync server

### DIFF
--- a/gumby/sync.py
+++ b/gumby/sync.py
@@ -130,7 +130,7 @@ class ExperimentServiceProto(LineReceiver):
         elif line.startswith(b"set:"):
             _, key, value = line.strip().split(b':', 2)
             self._logger.debug("This subscriber sets %s to %s", key, value)
-            self.vars[key] = value
+            self.vars[key.decode()] = value.decode()
             return 'init'
 
         elif line.strip() == b"ready":


### PR DESCRIPTION
Since in Python 3 these variables are in `bytes` format, we should properly `decode()` then before JSON dumping.