### PR TITLE
Improved yield_files to accept a file pattern

### DIFF
--- a/gumby/statsparser.py
+++ b/gumby/statsparser.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 import re
 
@@ -10,8 +11,21 @@ class StatisticsParser(object):
     def __init__(self, node_directory):
         self.node_directory = node_directory
 
-    def yield_files(self, file_to_check):
-        pattern = re.compile('[0-9]+')
+    def yield_files(self, file_pattern):
+        peer_pattern = re.compile('[0-9]+')
+
+        def find_matching_files(directory):
+            """
+            Recursively find files matching a specific pattern.
+            Returns the list of (absolute) filenames of files that match the pattern.
+            """
+            matching_files = []
+            for root, _, files in os.walk(directory):
+                for basename in files:
+                    if fnmatch.fnmatch(basename, file_pattern):
+                        filename = os.path.join(root, basename)
+                        matching_files.append(filename)
+            return matching_files
 
         # DAS structure
         for headnode in os.listdir(self.node_directory):
@@ -22,25 +36,29 @@ class StatisticsParser(object):
                     if os.path.isdir(nodedir):
                         for peer in os.listdir(nodedir):
                             peerdir = os.path.join(self.node_directory, headnode, node, peer)
-                            if os.path.isdir(peerdir) and pattern.match(peer):
+                            if os.path.isdir(peerdir) and peer_pattern.match(peer):
                                 try:
                                     peer_nr = int(peer)
 
-                                    filename = os.path.join(self.node_directory, headnode, node, peer, file_to_check)
-                                    if os.path.exists(filename) and os.stat(filename).st_size > 0:
-                                        yield peer_nr, filename, peerdir
+                                    dir_path = os.path.join(self.node_directory, headnode, node, peer)
+                                    matching_files = find_matching_files(dir_path)
+                                    for matching_file in matching_files:
+                                        if os.stat(matching_file).st_size > 0:
+                                            yield peer_nr, matching_file, peerdir
                                 except ValueError:
                                     break
 
         # Localhost structure
         for peer in os.listdir(self.node_directory):
             peerdir = os.path.join(self.node_directory, peer)
-            if os.path.isdir(peerdir) and pattern.match(peer):
+            if os.path.isdir(peerdir) and peer_pattern.match(peer):
                 peer_nr = int(peer)
 
-                filename = os.path.join(self.node_directory, peer, file_to_check)
-                if os.path.exists(filename) and os.stat(filename).st_size > 0:
-                    yield peer_nr, filename, peerdir
+                dir_path = os.path.join(self.node_directory, peer)
+                matching_files = find_matching_files(dir_path)
+                for matching_file in matching_files:
+                    if os.stat(matching_file).st_size > 0:
+                        yield peer_nr, matching_file, peerdir
 
     def run(self):
         pass

--- a/gumby/tests/test_statistics_parser.py
+++ b/gumby/tests/test_statistics_parser.py
@@ -33,9 +33,20 @@ class TestStatisticsParser(unittest.TestCase):
                     os.path.join(self.test_dir, "localhost", "node030", "1", "stats.txt"))
         shutil.copy(os.path.join(self.TESTS_DATA_DIR, "stats2.txt"),
                     os.path.join(self.test_dir, "localhost", "node031", "1", "stats.txt"))
+        with open(os.path.join(self.test_dir, "localhost", "node031", "1", "stats.bla"), "w") as test_file:
+            test_file.write("test test")
+        with open(os.path.join(self.test_dir, "localhost", "node031", "test.txt"), "w") as test_file:
+            # This file should not be considered in our queries since it is not located inside a peer directory
+            test_file.write("test test")
 
         items = stats_parser.yield_files('stats.txt')
         self.assertEqual(len(list(items)), 2)
+        items = stats_parser.yield_files('*.txt')
+        self.assertEqual(len(list(items)), 2)
+        items = stats_parser.yield_files('*.doesnotexist')
+        self.assertEqual(len(list(items)), 0)
+        items = stats_parser.yield_files('*.bla')
+        self.assertEqual(len(list(items)), 1)
 
     def test_yield_files_localhost(self):
         """
@@ -48,6 +59,11 @@ class TestStatisticsParser(unittest.TestCase):
         os.mkdir(os.path.join(self.test_dir, "2"))
         shutil.copy(os.path.join(self.TESTS_DATA_DIR, "stats1.txt"), os.path.join(self.test_dir, "1", "stats.txt"))
         shutil.copy(os.path.join(self.TESTS_DATA_DIR, "stats2.txt"), os.path.join(self.test_dir, "2", "stats.txt"))
+        with open(os.path.join(self.test_dir, "test.txt"), "w") as test_file:
+            # This file should not be considered in our queries since it is not located inside a peer directory
+            test_file.write("test test")
 
         items = stats_parser.yield_files('stats.txt')
+        self.assertEqual(len(list(items)), 2)
+        items = stats_parser.yield_files('*.txt')
         self.assertEqual(len(list(items)), 2)


### PR DESCRIPTION
The yield_files method now can recursively find files in the experiment output directory that matches a specific pattern. I've written some tests to verify correctness.