### PR TITLE
Assigning peer ID based on host IP

### DIFF
--- a/experiments/dummy/dummy_das5.conf
+++ b/experiments/dummy/dummy_das5.conf
@@ -17,13 +17,13 @@ use_local_venv = TRUE
 # The following options are used by das4_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
-das4_node_amount = 1
+das4_node_amount = 2
 
 # Kill the processes if they don't die after this many seconds
 das4_node_timeout = 20
 
 # How many processes do we want to spawn?
-das4_instances_to_run = 8
+das4_instances_to_run = 16
 
 # What command do we want to run?
 das4_node_command = "launch_scenario.py"

--- a/gumby/sync.py
+++ b/gumby/sync.py
@@ -193,6 +193,19 @@ class ExperimentServiceFactory(Factory):
             if self._made_looping_call and self._made_looping_call.running:
                 self._made_looping_call.stop()
 
+            # Assign IDs to the connected subscribers, based on their address
+            def split_ip(ip):
+                return tuple(int(part) for part in ip.split('.'))
+
+            def ip_addr_key(connection):
+                return split_ip(connection.transport.getPeer().host)
+
+            self.connections_made = sorted(self.connections_made, key=ip_addr_key)
+            peer_index = 1
+            for connection in self.connections_made:
+                connection.id = peer_index
+                peer_index += 1
+
             self.pushIdToSubscribers()
         else:
             if not self._made_looping_call:


### PR DESCRIPTION
Currently, peer IDs when running an experiment on the DAS5 are assigned on a first-come-first-serve basis. This makes peer assignment a very unpredictable and unreliable process, causing us to manually search amongst all node output for the artifacts of a peer with a specific ID.

This PR changes this behavior and assigns the peer IDs based on the host IP. This means that if you run an experiment on two DAS5 nodes with 16 instances in total, peer 1-8 will be assigned to instances running one host, and peer 9-16 will be assigned to instances on the other host. I changed the dummy experiment to allocate two nodes instead and verified its correctness.