### PR TITLE
Fixed compatibility with Tribler

### DIFF
--- a/experiments/tribler_idle_run/tribler_idle_run.py
+++ b/experiments/tribler_idle_run/tribler_idle_run.py
@@ -57,7 +57,7 @@ class IdleTribleRunner():
 
     async def run(self):
         config = TriblerConfig()
-        config.set_state_dir(os.path.abspath(os.path.join(BASE_DIR, "output", "tribler-state")),)
+        config.set_root_state_dir(os.path.abspath(os.path.join(BASE_DIR, "output", "tribler-state")),)
         config.set_http_api_enabled(False)
         config.set_ipv8_port(21000)
         config.set_libtorrent_port(21005)

--- a/gumby/anydex_config.py
+++ b/gumby/anydex_config.py
@@ -28,7 +28,7 @@ class AnyDexConfig(object):
     def get_trustchain_enabled(self):
         return self.config['trustchain']['enabled']
 
-    def set_state_dir(self, state_dir):
+    def set_root_state_dir(self, state_dir):
         self.config["general"]["state_dir"] = state_dir
 
     def get_state_dir(self):

--- a/gumby/modules/anydex_module.py
+++ b/gumby/modules/anydex_module.py
@@ -144,6 +144,6 @@ class AnyDexModule(ExperimentModule):
 
         config = AnyDexConfig()
         config.set_trustchain_keypair_filename("tc_keypair_" + str(self.experiment.my_id))
-        config.set_state_dir(my_state_path)
+        config.set_root_state_dir(my_state_path)
         config.set_ipv8_port(self.ipv8_port)
         return config

--- a/gumby/modules/base_ipv8_module.py
+++ b/gumby/modules/base_ipv8_module.py
@@ -114,7 +114,7 @@ class BaseIPv8Module(ExperimentModule):
 
         config = GumbyTriblerConfig()
         config.set_trustchain_keypair_filename("tc_keypair_" + str(self.experiment.my_id))
-        config.set_state_dir(my_state_path)
+        config.set_root_state_dir(my_state_path)
         config.set_torrent_checking_enabled(False)
         config.set_market_community_enabled(False)
         config.set_chant_enabled(False)

--- a/gumby/util.py
+++ b/gumby/util.py
@@ -1,3 +1,4 @@
+import os
 from asyncio import coroutine, ensure_future, iscoroutinefunction, sleep
 
 
@@ -14,12 +15,14 @@ def read_keypair_trustchain(keypairfilename):
 
 
 def save_keypair_trustchain(keypair, keypairfilename):
+    os.makedirs(os.path.dirname(keypairfilename), exist_ok=True)
     with open(keypairfilename, 'wb') as keyfile:
         keyfile.write(keypair.key.sk)
         keyfile.write(keypair.key.seed)
 
 
 def save_pub_key_trustchain(keypair, pubkeyfilename):
+    os.makedirs(os.path.dirname(pubkeyfilename), exist_ok=True)
     with open(pubkeyfilename, 'wb') as keyfile:
         keyfile.write(keypair.key.pk)
 


### PR DESCRIPTION
Fixed two incompatibilities with the current Tribler `devel` branch:
- Creating the root state directory structure before writing away the trustchain public/private keys.
- Renamed `get_state_dir` to `get_root_state_dir`.