### PR TITLE
Added basic bandwidth accounting experiment

### DIFF
--- a/experiments/bandwidth_accounting/__init__.py
+++ b/experiments/bandwidth_accounting/__init__.py
@@ -1,0 +1,3 @@
+"""
+This module contains the necessary files to experiment with the bandwidth accounting module.
+"""

--- a/experiments/bandwidth_accounting/bandwidth_accounting.conf
+++ b/experiments/bandwidth_accounting/bandwidth_accounting.conf
@@ -1,0 +1,37 @@
+experiment_name = "bandwidth_accounting"
+
+experiment_server_cmd = 'experiment_server.py'
+
+local_setup_cmd = 'das4_setup.sh'
+
+local_instance_cmd = 'das4_reserve_and_run.sh'
+
+post_process_cmd = 'post_process_bandwidth_accounting.sh'
+
+#Run python in optimized mode?
+use_local_venv = TRUE
+
+# The following options are used by das4_reserve_and_run.sh
+
+# How many nodes do we want? (seconds)
+das4_node_amount = 4
+
+# Kill the processes if they don't die after this many seconds
+das4_node_timeout = 350
+
+# How many processes do we want to spawn?
+das4_instances_to_run = 100
+
+# What command do we want to run?
+das4_node_command = "launch_scenario.py"
+
+scenario_file = 'bandwidth_accounting_basic.scenario'
+
+# The following options are used by the sync server
+
+# Delay between sending the experiment info and the start signal
+sync_experiment_start_delay = 1
+
+sync_port = __unique_port__
+
+tracker_port = __unique_port__

--- a/experiments/bandwidth_accounting/bandwidth_accounting_basic.scenario
+++ b/experiments/bandwidth_accounting/bandwidth_accounting_basic.scenario
@@ -1,0 +1,14 @@
+&module gumby.modules.tribler_module.TriblerModule
+&module experiments.bandwidth_accounting.bandwidth_accounting_module.BandwidthAccountingModule
+
+@0:1 isolate_ipv8_overlay BandwidthAccountingCommunity
+@0:2 start_session
+@0:10 introduce_peers max_peers=10
+@0:20 annotate start-payouts
+@0:20 start_payouts
+@0:50 stop_payouts
+@0:50 annotate stop-payouts
+@0:55 write_overlay_statistics
+@0:55 write_bandwidth_statistics
+@0:60 stop_session
+@0:65 stop

--- a/experiments/bandwidth_accounting/bandwidth_accounting_local.conf
+++ b/experiments/bandwidth_accounting/bandwidth_accounting_local.conf
@@ -1,0 +1,15 @@
+experiment_name = "bandwidth_accounting_local"
+experiment_time = 190
+
+experiment_server_cmd = 'experiment_server.py'
+sync_port = __unique_port__
+sync_host = 127.0.0.1
+sync_experiment_start_delay = 1
+sync_subscribers_amount = 2
+
+local_instance_cmd = "process_guard.py -c launch_scenario.py -n 2 -t $EXPERIMENT_TIME -m $OUTPUT_DIR -o $OUTPUT_DIR "
+
+scenario_file = 'bandwidth_accounting_basic.scenario'
+post_process_cmd = 'post_process_bandwidth_accounting.sh'
+
+use_local_venv = FALSE

--- a/experiments/bandwidth_accounting/bandwidth_accounting_module.py
+++ b/experiments/bandwidth_accounting/bandwidth_accounting_module.py
@@ -1,0 +1,38 @@
+import random
+
+from tribler_core.modules.bandwidth_accounting.community import BandwidthAccountingCommunity
+
+from gumby.experiment import experiment_callback
+from gumby.modules.community_experiment_module import IPv8OverlayExperimentModule
+from gumby.modules.experiment_module import static_module
+from gumby.util import run_task
+
+
+@static_module
+class BandwidthAccountingModule(IPv8OverlayExperimentModule):
+    def __init__(self, experiment):
+        super().__init__(experiment, BandwidthAccountingCommunity)
+        self.payouts_task = None
+
+    @experiment_callback
+    def start_payouts(self):
+        delay = random.random()
+
+        def start():
+            self._logger.info("Starting random payouts!")
+            self.payouts_task = run_task(self.do_random_payout, interval=1.0)
+
+        run_task(start, delay=delay)
+
+    def do_random_payout(self):
+        verified_peers = list(self.overlay.network.verified_peers)
+        random_peer = random.choice(verified_peers)
+        random_amount = random.randint(1 * 1024 * 1024, 10 * 1024 * 1024)
+        self._logger.info("Performing payout to peer %s with amount %d", random_peer, random_amount)
+        self.overlay.do_payout(random_peer, random_amount)
+
+    @experiment_callback
+    def stop_payouts(self):
+        self._logger.info("Stopping random payouts!")
+        if self.payouts_task:
+            self.payouts_task.cancel()

--- a/experiments/bandwidth_accounting/post_process_bandwidth_accounting.py
+++ b/experiments/bandwidth_accounting/post_process_bandwidth_accounting.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+from pony.orm import db_session
+
+from tribler_core.modules.bandwidth_accounting.database import BandwidthDatabase
+from tribler_core.modules.bandwidth_accounting.transaction import BandwidthTransactionData
+
+from gumby.statsparser import StatisticsParser
+
+
+class BandwidthStatisticsParser(StatisticsParser):
+    """
+    Parse TrustChain statistics after an experiment has been completed.
+    """
+
+    def __init__(self, node_directory):
+        super().__init__(node_directory)
+        self.output_dir = os.path.join(os.environ['PROJECT_DIR'], 'output')
+
+    def aggregate_databases(self):
+        transactions = []
+
+        for _, filename, _ in self.yield_files('bandwidth.db'):
+            print("Considering database %s" % os.path.abspath(filename))
+            db = BandwidthDatabase(Path(os.path.abspath(filename)), None)
+            with db_session:
+                db_txs = list(db.BandwidthTransaction.select())
+                for db_tx in db_txs:
+                    tx = BandwidthTransactionData.from_db(db_tx)
+                    transactions.append(tx)
+
+        print("Found %d transactions..." % len(transactions))
+        all_payouts_db = BandwidthDatabase(Path(self.output_dir) / "bandwidth.db", None)
+        for tx in transactions:
+            all_payouts_db.BandwidthTransaction.insert(tx)
+
+        with open("total_payout_edges.txt", "w") as out_file:
+            out_file.write("%d" % len(transactions))
+
+    def run(self):
+        self.aggregate_databases()
+
+
+# cd to the output directory
+os.chdir(os.environ['OUTPUT_DIR'])
+
+parser = BandwidthStatisticsParser(sys.argv[1])
+parser.run()

--- a/gumby/modules/base_ipv8_module.py
+++ b/gumby/modules/base_ipv8_module.py
@@ -12,12 +12,12 @@ from gumby.modules.gumby_session import GumbySession
 from gumby.modules.isolated_community_loader import IsolatedIPv8CommunityLoader
 from gumby.util import run_task
 
-from tribler_core.modules.ipv8_module_catalog import (DHTCommunityLauncher,
+from tribler_core.modules.ipv8_module_catalog import (BandwidthCommunityLauncher,
+                                                      DHTCommunityLauncher,
                                                       GigaChannelCommunityLauncher,
                                                       IPv8DiscoveryCommunityLauncher,
                                                       PopularityCommunityLauncher,
-                                                      TriblerTunnelCommunityLauncher,
-                                                      TrustChainCommunityLauncher)
+                                                      TriblerTunnelCommunityLauncher)
 
 
 class BaseIPv8Module(ExperimentModule):
@@ -59,11 +59,11 @@ class BaseIPv8Module(ExperimentModule):
     def create_ipv8_community_loader(self):
         loader = IsolatedIPv8CommunityLoader(self.session_id)
         loader.set_launcher(IPv8DiscoveryCommunityLauncher())
-        loader.set_launcher(TrustChainCommunityLauncher())
         loader.set_launcher(TriblerTunnelCommunityLauncher())
         loader.set_launcher(PopularityCommunityLauncher())
         loader.set_launcher(DHTCommunityLauncher())
         loader.set_launcher(GigaChannelCommunityLauncher())
+        loader.set_launcher(BandwidthCommunityLauncher())
         return loader
 
     @experiment_callback

--- a/scripts/post_process_bandwidth_accounting.sh
+++ b/scripts/post_process_bandwidth_accounting.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+gumby/experiments/bandwidth_accounting/post_process_bandwidth_accounting.py .
+
+# Run the regular statistics extraction script
+graph_process_guard_data.sh


### PR DESCRIPTION
This PR adds a basic bandwidth accounting experiment, following the merge of https://github.com/Tribler/tribler/pull/5626 in Tribler. The experiment initiates random bandwidth payouts with random users, and afterwards aggregates all payouts in a single database.

The validation experiment can be found [here](https://jenkins-ci.tribler.org/job/validation_experiments/job/validation_experiment_payouts/).