### PR TITLE
Fix compatibility with latest IPv8 version

### DIFF
--- a/gumby/modules/anydex_module.py
+++ b/gumby/modules/anydex_module.py
@@ -53,7 +53,7 @@ class TrustChainCommunityLauncher(CommunityLauncher):
 class MarketCommunityLauncher(CommunityLauncher):
 
     def not_before(self):
-        return ['DHTDiscoveryCommunity', 'TrustChainCommunity']
+        return ['DHTCommunityLauncher', 'TrustChainCommunityLauncher']
 
     def should_launch(self, session):
         return session.config.get_market_community_enabled()


### PR DESCRIPTION
This PR will ensure that the `MarketCommunityLauncher` works with the latest IPv8.

If compatibility with older versions is also required, we could return both the old and the new names in `not_before()`. This should be possible because IPv8 doesn't wait for non-existing launchers.