### PR TITLE
Fixed crash, fixed SYNC_HOST variable

### DIFF
--- a/docs/tutorials/experiment_tutorial_2.rst
+++ b/docs/tutorials/experiment_tutorial_2.rst
@@ -83,6 +83,8 @@ This synchronization process is coordinated by Gumby automatically.
 Recall that, in contrast to the previous experiment, we do not set the ``experiment_server_cmd`` configuration option
 to blank.
 This ensures that Gumby will spawn a synchronization server.
+The ``sync_host`` option specifies the IP address or host name of the machine running the synchronization server.
+In this experiment we set it to localhost.
 The ``sync_port`` option in the configuration file specifies the port of the synchronization server, and indicates to
 which port the spawned clients should connect. A value of ``__unique_port__`` indicates that Gumby will pick a random
 free port on runtime.

--- a/docs/tutorials/simple_ipv8.conf
+++ b/docs/tutorials/simple_ipv8.conf
@@ -4,4 +4,5 @@ instances_to_run = 2
 local_instance_cmd = "process_guard.py -c launch_scenario.py -n $INSTANCES_TO_RUN -t $EXPERIMENT_TIME -m $OUTPUT_DIR -o $OUTPUT_DIR "
 post_process_cmd = graph_process_guard_data.sh
 scenario_file = simple_ipv8.scenario
+sync_host = localhost
 sync_port = __unique_port__

--- a/docs/tutorials/synchronized_instances.conf
+++ b/docs/tutorials/synchronized_instances.conf
@@ -7,5 +7,6 @@ post_process_cmd = post_process_write_ids.sh
 # The scenario file to run after an instance has spawned.
 scenario_file = write_ids.scenario
 
-# The port of the synchronization server.
+# The host and port of the synchronization server.
+sync_host = localhost
 sync_port = __unique_port__

--- a/gumby/launch_scenario.py
+++ b/gumby/launch_scenario.py
@@ -26,7 +26,10 @@ def setup_environment_gumby():
             environ["EXPERIMENT_DIR"] = path.abspath(path.join(environ["PROJECT_DIR"], "experiments", "dummy"))
 
     if "SYNC_HOST" not in environ:
-        environ["SYNC_HOST"] = "localhost"
+        if "SSH_CONNECTION" in environ:
+            environ["SYNC_HOST"] = environ["SSH_CONNECTION"].split(" ")[0]
+        else:
+            environ["SYNC_HOST"] = "localhost"
 
     if environ["EXPERIMENT_DIR"] not in python_path:
         python_path.append(environ["EXPERIMENT_DIR"])

--- a/gumby/launch_scenario.py
+++ b/gumby/launch_scenario.py
@@ -15,8 +15,8 @@ def setup_environment_gumby():
     """
     Setup Gumby-related environment variables.
     """
-    environ["PROJECT_DIR"] = environ["PROJECT_DIR"] or path.abspath(path.join(path.dirname(__file__), ".."))
-    environ["OUTPUT_DIR"] = environ["OUTPUT_DIR"] or path.abspath(path.join(environ["PROJECT_DIR"], "output"))
+    environ["PROJECT_DIR"] = environ.get("PROJECT_DIR", None) or path.abspath(path.join(path.dirname(__file__), ".."))
+    environ["OUTPUT_DIR"] = environ.get("OUTPUT_DIR", None) or path.abspath(path.join(environ["PROJECT_DIR"], "output"))
 
     if "EXPERIMENT_DIR" not in environ:
         if "SCENARIO_FILE" in environ:


### PR DESCRIPTION
This PR:
- Fixes a crash when the `PROJECT_DIR` environment variable was not set at the client side.
- Restores the code that sets the `SYNC_HOST` environment variable to the host of the SSH connection (this logic is used when Gumby uses remote SSH connections to nodes).