### PR TITLE
Fix validation experiments after scripts' renaming

### DIFF
--- a/experiments/algorand/algorand_experiment.conf
+++ b/experiments/algorand/algorand_experiment.conf
@@ -1,14 +1,14 @@
 experiment_name = "algorand_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = post_process_algorand.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/algorand/algorand_surfnet_experiment.conf
+++ b/experiments/algorand/algorand_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_algorand.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/avalanche/avalanche_surfnet_experiment.conf
+++ b/experiments/avalanche/avalanche_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_algorand.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/bandwidth_accounting/bandwidth_accounting.conf
+++ b/experiments/bandwidth_accounting/bandwidth_accounting.conf
@@ -1,15 +1,15 @@
 experiment_name = "bandwidth_accounting"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_bandwidth_accounting.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 4

--- a/experiments/basalt/basalt_das5.conf
+++ b/experiments/basalt/basalt_das5.conf
@@ -1,15 +1,15 @@
 experiment_name = "basalt"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_basalt.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 4

--- a/experiments/bitshares/bitshares_experiment.conf
+++ b/experiments/bitshares/bitshares_experiment.conf
@@ -1,14 +1,14 @@
 experiment_name = "bitshares_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_bitshares.sh'
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/bitshares/bitshares_surfnet_experiment.conf
+++ b/experiments/bitshares/bitshares_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_bitshares.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/burrow/burrow_experiment.conf
+++ b/experiments/burrow/burrow_experiment.conf
@@ -1,8 +1,8 @@
 experiment_name = "burrow_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = post_process_burrow.sh
 
@@ -10,7 +10,7 @@ post_process_cmd = post_process_burrow.sh
 PYTHONOPTIMIZE = yup
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/burrow/burrow_surfnet_experiment.conf
+++ b/experiments/burrow/burrow_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_ethereum.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/dht/dht_experiment.das4.conf
+++ b/experiments/dht/dht_experiment.das4.conf
@@ -1,16 +1,16 @@
 
 experiment_name = "dht_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_dht_experiment.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 2

--- a/experiments/ethereum/ethereum_experiment.conf
+++ b/experiments/ethereum/ethereum_experiment.conf
@@ -1,14 +1,14 @@
 experiment_name = "ethereum_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = post_process_ethereum.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/ethereum/ethereum_surfnet_experiment.conf
+++ b/experiments/ethereum/ethereum_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_ethereum.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/gigachannel/gigachannel_das5.conf
+++ b/experiments/gigachannel/gigachannel_das5.conf
@@ -1,15 +1,15 @@
 experiment_name = "gigachannel"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_ipv8_experiment.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/hyperledger/hyperledger_experiment.conf
+++ b/experiments/hyperledger/hyperledger_experiment.conf
@@ -1,14 +1,14 @@
 experiment_name = "hyperledger_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = post_process_hyperledger.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/hyperledger/hyperledger_surfnet_experiment.conf
+++ b/experiments/hyperledger/hyperledger_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_hyperledger.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/ipv8/ipv8_experiment.conf
+++ b/experiments/ipv8/ipv8_experiment.conf
@@ -1,16 +1,16 @@
 
 experiment_name = "ipv8_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_ipv8_experiment.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/libra/libra_experiment.conf
+++ b/experiments/libra/libra_experiment.conf
@@ -1,14 +1,14 @@
 experiment_name = "libra_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = post_process_libra.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/libra/libra_surfnet_experiment.conf
+++ b/experiments/libra/libra_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_libra.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/market/market_experiment.conf
+++ b/experiments/market/market_experiment.conf
@@ -1,16 +1,16 @@
 
 experiment_name = "market_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_market_experiment.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/popularity/popularity_experiment.conf
+++ b/experiments/popularity/popularity_experiment.conf
@@ -1,15 +1,15 @@
 experiment_name = "popularity_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_ipv8_experiment.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/stellar/stellar_experiment.conf
+++ b/experiments/stellar/stellar_experiment.conf
@@ -1,14 +1,14 @@
 experiment_name = "stellar_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = post_process_stellar.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/stellar/stellar_surfnet_experiment.conf
+++ b/experiments/stellar/stellar_surfnet_experiment.conf
@@ -10,7 +10,7 @@ post_process_cmd = post_process_stellar.sh
 
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/experiments/trustchain/trustchain.conf
+++ b/experiments/trustchain/trustchain.conf
@@ -1,15 +1,15 @@
 experiment_name = "trustchain"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_trustchain.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 4

--- a/experiments/tunnels/tunnel_das4.conf
+++ b/experiments/tunnels/tunnel_das4.conf
@@ -1,15 +1,15 @@
 experiment_name = "tunnel_experiment"
 
-local_setup_cmd = 'das4_setup.sh'
+local_setup_cmd = 'das_setup.sh'
 
-local_instance_cmd = 'das4_reserve_and_run.sh'
+local_instance_cmd = 'das_reserve_and_run.sh'
 
 post_process_cmd = 'post_process_tunnel_experiment.sh'
 
 #Run python in optimized mode?
 use_local_venv = TRUE
 
-# The following options are used by das4_reserve_and_run.sh
+# The following options are used by das_reserve_and_run.sh
 
 # How many nodes do we want? (seconds)
 node_amount = 1

--- a/scripts/das_node_run_job.sh
+++ b/scripts/das_node_run_job.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script is called from das4_reserve_and_run.sh and spawns N copies of the specified command, sending the output
+# This script is called from das_reserve_and_run.sh and spawns N copies of the specified command, sending the output
 # data back to the head node when finished.
 let "PROCESSES_PER_NODE=$INSTANCES_TO_RUN/$NODE_AMOUNT"
 let "PLUS_ONE_NODES=$INSTANCES_TO_RUN%$NODE_AMOUNT"


### PR DESCRIPTION
Fixes #521

PR #518 renamed some scripts:
* das4_node_run_job.sh -> das_node_run_job.sh
* das4_reserve_and_run.sh -> das_reserve_and_run.sh
* das4_setup.sh -> das_setup.sh

But in some configuration files, old script names remain. Because of this, validation experiments stopped working.
In this PR, I'm fixing configuration files to restore validation experiments.

P.S. To check the fix, I temporarily pointed the [`Clone_gumby_devel`](https://jenkins-ci.tribler.org/job/Clone_gumby_devel/) Jenkins job to my PR instead of the `devel` branch.